### PR TITLE
ci: bump Node 20 -> 24 (CI, Docker, scripts, docs)

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -3,9 +3,9 @@ description: 'Setup Node.js with npm caching for the frontend project'
 runs:
   using: 'composite'
   steps:
-    - name: Setup Node.js 20
+    - name: Setup Node.js 24
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '24'
         cache: 'npm'
         cache-dependency-path: './lighthouse-front/package-lock.json'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: Checkout frontend
         uses: actions/checkout@v4
-      - name: Setup Node.js 20
+      - name: Setup Node.js 24
         uses: ./.github/actions/setup-node
       - name: Install dependencies
         working-directory: ./lighthouse-front

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
     with:
       version: ${{ needs.release.outputs.version }}
       working-directory: lighthouse-front
-      node-version: '20'
+      node-version: '24'
       run-tests: true
       test-command: 'test -- --run'
     secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,7 +310,7 @@ The application can update itself via GitHub releases:
 
 - Docker Desktop (Windows/Mac) or Docker Engine (Linux)
 - .NET 10 SDK
-- Node.js 20+ and npm
+- Node.js 24+ and npm
 - Git
 
 ### Local Development (Without Docker)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ chmod +x dev-setup/setup.sh run.sh   # first time only
 ./dev-setup/setup.sh
 ```
 
-Prerequisites it checks/installs: **Git**, **.NET SDK 10**, **Node.js 20+**,
+Prerequisites it checks/installs: **Git**, **.NET SDK 10**, **Node.js 24+**,
 **Docker**. Details and manual steps: [dev-setup/README.md](dev-setup/README.md).
 
 ## 2. Run the app

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN dotnet publish -c Release -o /app/backend \
     echo "${VERSION}" > /app/backend/VERSION
 
 # Stage 2: Build Frontend
-FROM node:20-alpine AS frontend-build
+FROM node:24-alpine AS frontend-build
 WORKDIR /app
 
 # Copy frontend package files and install dependencies

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ volumes:
 ### Prerequisites
 - Docker Desktop or Docker Engine
 - .NET 10 SDK
-- Node.js 20+
+- Node.js 24+
 
 > **Fastest path:** run `dev-setup/setup.ps1` (Windows) or `dev-setup/setup.sh`
 > (Linux/macOS) to install prerequisites and configure everything, then `run.ps1`

--- a/dev-setup/README.md
+++ b/dev-setup/README.md
@@ -24,7 +24,7 @@ Then open <http://localhost:5173> and log in with **`admin` / `adminadmin`**
 `setup.ps1` / `setup.sh` is **install + configure only — it never launches the app**:
 
 1. **Detects prerequisites** and prints each version (or `MISSING`):
-   - git, .NET SDK (>= 10), Node.js (>= 20), npm, Docker (+ daemon reachable).
+   - git, .NET SDK (>= 10), Node.js (>= 24), npm, Docker (+ daemon reachable).
 2. **Prompts before installing** anything missing (hybrid — nothing is installed
    without a `Y`). Uses `winget`/`choco` on Windows, `brew` on macOS, and
    `apt`/`dnf`/`pacman` on Linux. If no package manager is found it prints the
@@ -84,7 +84,7 @@ npm run dev
 |-------------|----------|--------------------------------------------------------------|
 | Git         | yes      | <https://git-scm.com/downloads>                              |
 | .NET SDK 10 | yes      | <https://dotnet.microsoft.com/download/dotnet/10.0>          |
-| Node.js 20+ | yes      | <https://nodejs.org/>                                        |
+| Node.js 24+ | yes      | <https://nodejs.org/>                                        |
 | Docker      | yes      | <https://www.docker.com/products/docker-desktop/>           |
 
 Then create the two config files listed in step 3 above and run

--- a/dev-setup/setup.ps1
+++ b/dev-setup/setup.ps1
@@ -88,16 +88,16 @@ if (Test-Command dotnet) {
     $missing += "dotnet"
 }
 
-# Node (require major >= 20)
+# Node (require major >= 24)
 $nodeOk = $false
 if (Test-Command node) {
     $nodeVer = (node -v).TrimStart('v')
     $nodeMajor = [int]($nodeVer.Split('.')[0])
-    if ($nodeMajor -ge 20) {
+    if ($nodeMajor -ge 24) {
         Write-Host "  Node      OK   v$nodeVer" -ForegroundColor Green
         $nodeOk = $true
     } else {
-        Write-Host "  Node      TOO OLD (v$nodeVer, need >= 20)" -ForegroundColor Red
+        Write-Host "  Node      TOO OLD (v$nodeVer, need >= 24)" -ForegroundColor Red
         $missing += "node"
     }
 } else {

--- a/dev-setup/setup.sh
+++ b/dev-setup/setup.sh
@@ -83,10 +83,10 @@ fi
 node_ok=0
 if has node; then
     nver="$(node -v)"; nver="${nver#v}"; nmaj="${nver%%.*}"
-    if [ "$nmaj" -ge 20 ] 2>/dev/null; then
+    if [ "$nmaj" -ge 24 ] 2>/dev/null; then
         echo -e "  Node      ${GREEN}OK${NC}   v$nver"; node_ok=1
     else
-        echo -e "  Node      ${RED}TOO OLD${NC} (v$nver, need >= 20)"; missing+=("node")
+        echo -e "  Node      ${RED}TOO OLD${NC} (v$nver, need >= 24)"; missing+=("node")
     fi
 else
     echo -e "  Node      ${RED}MISSING${NC}"; missing+=("node")
@@ -110,7 +110,7 @@ if [ "${#missing[@]}" -gt 0 ]; then
         case "$tool" in
             git)    brew_p="git";          apt_p="git";          dnf_p="git";          pac_p="git";          url="https://git-scm.com/downloads" ;;
             dotnet) brew_p="dotnet-sdk";   apt_p="dotnet-sdk-10.0"; dnf_p="dotnet-sdk-10.0"; pac_p="dotnet-sdk"; url="https://dotnet.microsoft.com/download/dotnet/10.0" ;;
-            node)   brew_p="node@20";      apt_p="nodejs npm";   dnf_p="nodejs";       pac_p="nodejs npm";   url="https://nodejs.org/" ;;
+            node)   brew_p="node@24";      apt_p="nodejs npm";   dnf_p="nodejs";       pac_p="nodejs npm";   url="https://nodejs.org/" ;;
             docker) brew_p="--cask docker"; apt_p="docker.io";   dnf_p="docker";       pac_p="docker";       url="https://docs.docker.com/engine/install/" ;;
         esac
         if read_yesno "  Install '$tool' now?"; then

--- a/lighthouse-front/Dockerfile
+++ b/lighthouse-front/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine AS build
+FROM node:24-alpine AS build
 
 WORKDIR /app
 

--- a/lighthouse-front/package.json
+++ b/lighthouse-front/package.json
@@ -4,7 +4,7 @@
 	"version": "0.0.1",
 	"type": "module",
 	"engines": {
-		"node": ">=20"
+		"node": ">=24"
 	},
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## What

Bump Node from **20 to 24** (current LTS, ships npm 11) everywhere it was pinned: CI, both Docker build stages, the dev-setup scripts, the docs, and `engines.node`.

## Why

Recent local toolchains (Node 22+/npm 11) regenerate `package-lock.json` in a shape that **npm 10 (Node 20) rejects**, which caused lockfile-sync CI failures and forced churn. Aligning CI/Docker on Node 24 (npm 11) matches what contributors on recent Node already produce, ending the back-and-forth.

npm 11 reads the existing npm-10 lockfile fine (verified with a clean `npm ci`, exit 0), so **no lockfile regeneration** is included here — the diff stays to version strings only.

## Changes

- CI: `setup-node` composite action, `pr-ci` step name, `release.yml` -> Node 24
- Docker: root `Dockerfile` and `lighthouse-front/Dockerfile` -> `node:24-alpine`
- dev-setup: `setup.ps1` / `setup.sh` require Node >= 24 (check + messages + Homebrew `node@24`)
- docs: README, CLAUDE, CONTRIBUTING, dev-setup/README -> Node.js 24+
- `lighthouse-front/package.json` `engines.node` -> `>=24`

## Note

Labeled `release-patch`, so merging also cuts the first release carrying the **Lighthouse** rebrand (image `ghcr.io/jordanolivet/lighthouse`). Already-deployed instances poll the old image name — they must self-update once via the old image before the switch takes effect; call this out in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
