### PR TITLE
refactor: extract RegistryClientBase + characterization tests (PR5b)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,11 @@ cd lighthouse-back && dotnet test
 
 - Backend tests live in `lighthouse-back.Tests/` (xUnit + Moq +
   FluentAssertions). Add tests for new services/controllers.
+- Some tests hit real external services and are **skipped by default** (so CI and
+  a plain `dotnet test` stay offline). The registry clients have opt-in
+  integration tests — see
+  [`lighthouse-back.Tests/Services/Registry/README.md`](lighthouse-back/lighthouse-back.Tests/Services/Registry/README.md)
+  for how to run them (`RUN_REGISTRY_INTEGRATION=1 dotnet test --filter Category=RegistryIntegration`).
 - The frontend has no automated test suite yet; run `npm run check` (also covered
   by `build-check`) and verify manually.
 

--- a/lighthouse-back/lighthouse-back.Tests/Services/Registry/DockerHubRegistryClientTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/Registry/DockerHubRegistryClientTests.cs
@@ -1,0 +1,136 @@
+using FluentAssertions;
+using Lighthouse.Configuration;
+using Lighthouse.Services;
+using Lighthouse.Services.Registry;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Lighthouse.Tests.Services.Registry;
+
+/// <summary>
+/// Characterization tests pinning the externally observable behaviour of
+/// <see cref="DockerHubRegistryClient"/> before/after the base-class refactor.
+/// </summary>
+public class DockerHubRegistryClientTests
+{
+    private const string TokenUrlMarker = "auth.docker.io/token";
+
+    private static DockerHubRegistryClient CreateClient(
+        Func<HttpRequestMessage, HttpResponseMessage> responder,
+        out FakeHttpMessageHandler handler)
+    {
+        handler = new FakeHttpMessageHandler(responder);
+        var credentials = new Mock<IRegistryCredentialService>();
+        credentials
+            .Setup(c => c.GetRawCredentialsAsync(It.IsAny<string>()))
+            .ReturnsAsync(((string Username, string Password)?)null);
+
+        return new DockerHubRegistryClient(
+            handler.CreateClient(),
+            Options.Create(new UpdateCheckOptions { TimeoutSeconds = 30 }),
+            credentials.Object,
+            new NullLogger<DockerHubRegistryClient>());
+    }
+
+    [Fact]
+    public void CanHandle_RecognizesDockerHubHosts()
+    {
+        DockerHubRegistryClient client = CreateClient(_ => RegistryResponses.NotFound(), out _);
+        client.CanHandle("docker.io").Should().BeTrue();
+        client.CanHandle("registry-1.docker.io").Should().BeTrue();
+        client.CanHandle("ghcr.io").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetManifestDigestAsync_SingleArchHead_ReturnsContentDigest()
+    {
+        DockerHubRegistryClient client = CreateClient(req =>
+        {
+            if (req.RequestUri!.ToString().Contains(TokenUrlMarker))
+                return RegistryResponses.Json("{\"token\":\"tok\"}");
+            if (req.Method == HttpMethod.Head)
+                return RegistryResponses.Head(System.Net.HttpStatusCode.OK, "sha256:headdigest");
+            return RegistryResponses.NotFound();
+        }, out _);
+
+        string? digest = await client.GetManifestDigestAsync("library/nginx", "latest", "amd64");
+
+        digest.Should().Be("sha256:headdigest");
+    }
+
+    [Fact]
+    public async Task GetManifestDigestAsync_TokenRequestFails_ReturnsNull()
+    {
+        DockerHubRegistryClient client = CreateClient(req =>
+        {
+            if (req.RequestUri!.ToString().Contains(TokenUrlMarker))
+                return RegistryResponses.Json("nope", System.Net.HttpStatusCode.InternalServerError);
+            return RegistryResponses.Head(System.Net.HttpStatusCode.OK, "sha256:never");
+        }, out _);
+
+        string? digest = await client.GetManifestDigestAsync("library/nginx", "latest", "amd64");
+
+        digest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetManifestDigestAsync_RateLimitedOnToken_Throws()
+    {
+        DockerHubRegistryClient client = CreateClient(_ => RegistryResponses.TooManyRequests(), out _);
+
+        Func<Task> act = () => client.GetManifestDigestAsync("library/nginx", "latest", "amd64");
+
+        await act.Should().ThrowAsync<RegistryRateLimitException>();
+    }
+
+    [Fact]
+    public async Task GetManifestDigestAndCreatedAtAsync_MultiArch_ReturnsListDigestAndCreatedAt()
+    {
+        DockerHubRegistryClient client = CreateClient(req =>
+        {
+            string url = req.RequestUri!.ToString();
+            if (url.Contains(TokenUrlMarker))
+                return RegistryResponses.Json("{\"token\":\"tok\"}");
+            if (url.Contains("/blobs/"))
+                return RegistryResponses.Json(RegistryResponses.ConfigBlobBody("2026-01-02T03:04:05Z"));
+            if (url.Contains("/manifests/sha256:archman"))
+                return RegistryResponses.Manifest(RegistryResponses.ManifestContentType,
+                    RegistryResponses.ManifestBody("sha256:cfg"));
+            // GET manifests/latest -> manifest list
+            return RegistryResponses.Manifest(
+                RegistryResponses.ManifestListContentType,
+                RegistryResponses.ManifestListBody("amd64", "sha256:archman"),
+                dockerContentDigest: "sha256:listdigest");
+        }, out _);
+
+        (string? digest, DateTime? createdAt) =
+            await client.GetManifestDigestAndCreatedAtAsync("library/nginx", "latest", "amd64");
+
+        digest.Should().Be("sha256:listdigest");
+        createdAt.Should().Be(new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc).ToLocalTime());
+    }
+
+    [Fact]
+    public async Task GetManifestDigestAndCreatedAtAsync_SingleArch_ReturnsDigestAndCreatedAt()
+    {
+        DockerHubRegistryClient client = CreateClient(req =>
+        {
+            string url = req.RequestUri!.ToString();
+            if (url.Contains(TokenUrlMarker))
+                return RegistryResponses.Json("{\"token\":\"tok\"}");
+            if (url.Contains("/blobs/"))
+                return RegistryResponses.Json(RegistryResponses.ConfigBlobBody("2026-05-06T07:08:09Z"));
+            return RegistryResponses.Manifest(
+                RegistryResponses.ManifestContentType,
+                RegistryResponses.ManifestBody("sha256:cfg"),
+                dockerContentDigest: "sha256:singledigest");
+        }, out _);
+
+        (string? digest, DateTime? createdAt) =
+            await client.GetManifestDigestAndCreatedAtAsync("library/nginx", "latest", "amd64");
+
+        digest.Should().Be("sha256:singledigest");
+        createdAt.Should().Be(new DateTime(2026, 5, 6, 7, 8, 9, DateTimeKind.Utc).ToLocalTime());
+    }
+}

--- a/lighthouse-back/lighthouse-back.Tests/Services/Registry/FakeHttpMessageHandler.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/Registry/FakeHttpMessageHandler.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Lighthouse.Tests.Services.Registry;
+
+/// <summary>
+/// Programmable <see cref="HttpMessageHandler"/> for registry-client tests. Routes each request to a
+/// caller-supplied responder and records the requests it saw, so tests can assert on the sequence of
+/// calls (token endpoint, HEAD/GET manifest, config blob, ...).
+/// </summary>
+public sealed class FakeHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+
+    public List<(HttpMethod Method, string Url)> Requests { get; } = new();
+
+    public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+    {
+        _responder = responder;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        Requests.Add((request.Method, request.RequestUri!.ToString()));
+        return Task.FromResult(_responder(request));
+    }
+
+    public HttpClient CreateClient() => new(this);
+}
+
+/// <summary>
+/// Helpers to build the registry HTTP responses used by the characterization tests.
+/// </summary>
+public static class RegistryResponses
+{
+    public const string ManifestListContentType = "application/vnd.docker.distribution.manifest.list.v2+json";
+    public const string ManifestContentType = "application/vnd.docker.distribution.manifest.v2+json";
+
+    /// <summary>Manifest response carrying a Docker-Content-Digest header and a body.</summary>
+    public static HttpResponseMessage Manifest(string contentType, string body, string? dockerContentDigest = null)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body)
+        };
+        response.Content.Headers.ContentType = new MediaTypeHeaderValue(contentType.Split(';')[0]);
+        if (dockerContentDigest != null)
+        {
+            response.Headers.TryAddWithoutValidation("Docker-Content-Digest", dockerContentDigest);
+        }
+        return response;
+    }
+
+    /// <summary>HEAD response: status + optional Docker-Content-Digest header, no body.</summary>
+    public static HttpResponseMessage Head(HttpStatusCode status, string? dockerContentDigest = null)
+    {
+        var response = new HttpResponseMessage(status);
+        if (dockerContentDigest != null)
+        {
+            response.Headers.TryAddWithoutValidation("Docker-Content-Digest", dockerContentDigest);
+        }
+        return response;
+    }
+
+    public static HttpResponseMessage Json(string body, HttpStatusCode status = HttpStatusCode.OK)
+        => new(status) { Content = new StringContent(body) };
+
+    public static HttpResponseMessage TooManyRequests()
+        => new(HttpStatusCode.TooManyRequests) { Content = new StringContent("rate limited") };
+
+    /// <summary>401 with a Bearer WWW-Authenticate challenge pointing at a token realm.</summary>
+    public static HttpResponseMessage Unauthorized(string realm, string service, string scope)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+        response.Headers.TryAddWithoutValidation(
+            "WWW-Authenticate", $"Bearer realm=\"{realm}\",service=\"{service}\",scope=\"{scope}\"");
+        return response;
+    }
+
+    public static HttpResponseMessage NotFound() => new(HttpStatusCode.NotFound);
+
+    /// <summary>A docker manifest list (image index) body for the given arch → manifest digest.</summary>
+    public static string ManifestListBody(string architecture, string archManifestDigest)
+        => $$"""
+        {
+          "manifests": [
+            { "platform": { "architecture": "{{architecture}}", "os": "linux" }, "digest": "{{archManifestDigest}}" }
+          ]
+        }
+        """;
+
+    /// <summary>A single image manifest body referencing a config blob digest.</summary>
+    public static string ManifestBody(string configDigest)
+        => $$"""
+        { "config": { "digest": "{{configDigest}}" } }
+        """;
+
+    /// <summary>A config blob body with a created timestamp.</summary>
+    public static string ConfigBlobBody(string createdIso)
+        => $$"""
+        { "created": "{{createdIso}}" }
+        """;
+}

--- a/lighthouse-back/lighthouse-back.Tests/Services/Registry/GenericOciRegistryClientTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/Registry/GenericOciRegistryClientTests.cs
@@ -1,0 +1,93 @@
+using FluentAssertions;
+using Lighthouse.Configuration;
+using Lighthouse.Services.Registry;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Lighthouse.Tests.Services.Registry;
+
+/// <summary>
+/// Characterization tests pinning the externally observable behaviour of
+/// <see cref="GenericOciRegistryClient"/> (the fallback client; derives registry/repository
+/// from the image reference and authenticates via the WWW-Authenticate challenge).
+/// </summary>
+public class GenericOciRegistryClientTests
+{
+    private const string Image = "myreg.io/owner/repo";
+
+    private static GenericOciRegistryClient CreateClient(
+        Func<HttpRequestMessage, HttpResponseMessage> responder)
+    {
+        var handler = new FakeHttpMessageHandler(responder);
+        return new GenericOciRegistryClient(
+            handler.CreateClient(),
+            Options.Create(new UpdateCheckOptions { TimeoutSeconds = 30 }),
+            new NullLogger<GenericOciRegistryClient>());
+    }
+
+    [Fact]
+    public void CanHandle_AlwaysTrue()
+    {
+        GenericOciRegistryClient client = CreateClient(_ => RegistryResponses.NotFound());
+        client.CanHandle("anything.example.com").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetManifestDigestAsync_AnonymousHead_ReturnsDigest()
+    {
+        GenericOciRegistryClient client = CreateClient(req =>
+            req.Method == HttpMethod.Head
+                ? RegistryResponses.Head(System.Net.HttpStatusCode.OK, "sha256:generichead")
+                : RegistryResponses.NotFound());
+
+        string? digest = await client.GetManifestDigestAsync(Image, "latest", "amd64");
+
+        digest.Should().Be("sha256:generichead");
+    }
+
+    [Fact]
+    public async Task GetManifestDigestAsync_AnonymousFailsThenTokenChallenge_ReturnsDigest()
+    {
+        GenericOciRegistryClient client = CreateClient(req =>
+        {
+            string url = req.RequestUri!.ToString();
+            if (url.Contains("/token"))
+                return RegistryResponses.Json("{\"token\":\"tok\"}");
+            // Anonymous HEAD fails → null, triggering the token challenge.
+            if (req.Method == HttpMethod.Head && req.Headers.Authorization == null)
+                return RegistryResponses.NotFound();
+            // Authenticated HEAD succeeds.
+            if (req.Method == HttpMethod.Head)
+                return RegistryResponses.Head(System.Net.HttpStatusCode.OK, "sha256:genauthed");
+            // GET manifests/latest with no auth → 401 challenge (used by the token probe).
+            if (req.Method == HttpMethod.Get && req.Headers.Authorization == null)
+                return RegistryResponses.Unauthorized("https://myreg.io/token", "myreg.io", "repository:owner/repo:pull");
+            return RegistryResponses.NotFound();
+        });
+
+        string? digest = await client.GetManifestDigestAsync(Image, "latest", "amd64");
+
+        digest.Should().Be("sha256:genauthed");
+    }
+
+    [Fact]
+    public async Task GetManifestDigestAndCreatedAtAsync_SingleArchAnonymous_ReturnsDigestAndCreatedAt()
+    {
+        GenericOciRegistryClient client = CreateClient(req =>
+        {
+            string url = req.RequestUri!.ToString();
+            if (url.Contains("/blobs/"))
+                return RegistryResponses.Json(RegistryResponses.ConfigBlobBody("2026-09-10T11:12:13Z"));
+            return RegistryResponses.Manifest(
+                RegistryResponses.ManifestContentType,
+                RegistryResponses.ManifestBody("sha256:cfg"),
+                dockerContentDigest: "sha256:gensingle");
+        });
+
+        (string? digest, DateTime? createdAt) =
+            await client.GetManifestDigestAndCreatedAtAsync(Image, "latest", "amd64");
+
+        digest.Should().Be("sha256:gensingle");
+        createdAt.Should().Be(new DateTime(2026, 9, 10, 11, 12, 13, DateTimeKind.Utc).ToLocalTime());
+    }
+}

--- a/lighthouse-back/lighthouse-back.Tests/Services/Registry/GhcrRegistryClientTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/Registry/GhcrRegistryClientTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using Lighthouse.Configuration;
+using Lighthouse.Services.Registry;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Lighthouse.Tests.Services.Registry;
+
+/// <summary>
+/// Characterization tests pinning the externally observable behaviour of
+/// <see cref="GhcrRegistryClient"/> (anonymous / no GitHub token configured).
+/// </summary>
+public class GhcrRegistryClientTests
+{
+    private static GhcrRegistryClient CreateClient(
+        Func<HttpRequestMessage, HttpResponseMessage> responder)
+    {
+        var handler = new FakeHttpMessageHandler(responder);
+        IConfiguration configuration = new ConfigurationBuilder().Build(); // no GitHub:Token → anonymous
+        return new GhcrRegistryClient(
+            handler.CreateClient(),
+            Options.Create(new UpdateCheckOptions { TimeoutSeconds = 30 }),
+            configuration,
+            new NullLogger<GhcrRegistryClient>());
+    }
+
+    [Fact]
+    public void CanHandle_OnlyGhcr()
+    {
+        GhcrRegistryClient client = CreateClient(_ => RegistryResponses.NotFound());
+        client.CanHandle("ghcr.io").Should().BeTrue();
+        client.CanHandle("docker.io").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetManifestDigestAsync_AnonymousHead_ReturnsDigest()
+    {
+        GhcrRegistryClient client = CreateClient(req =>
+            req.Method == HttpMethod.Head
+                ? RegistryResponses.Head(System.Net.HttpStatusCode.OK, "sha256:ghcrhead")
+                : RegistryResponses.NotFound());
+
+        string? digest = await client.GetManifestDigestAsync("owner/repo", "latest", "amd64");
+
+        digest.Should().Be("sha256:ghcrhead");
+    }
+
+    [Fact]
+    public async Task GetManifestDigestAsync_HeadUnauthorizedThenToken_ReturnsDigest()
+    {
+        GhcrRegistryClient client = CreateClient(req =>
+        {
+            string url = req.RequestUri!.ToString();
+            if (url.Contains("/token"))
+                return RegistryResponses.Json("{\"token\":\"tok\"}");
+            if (req.Method == HttpMethod.Head && req.Headers.Authorization != null)
+                return RegistryResponses.Head(System.Net.HttpStatusCode.OK, "sha256:authedhead");
+            if (req.Method == HttpMethod.Head)
+                return RegistryResponses.Unauthorized("https://ghcr.io/token", "ghcr.io", "repository:owner/repo:pull");
+            return RegistryResponses.NotFound();
+        });
+
+        string? digest = await client.GetManifestDigestAsync("owner/repo", "latest", "amd64");
+
+        digest.Should().Be("sha256:authedhead");
+    }
+
+    [Fact]
+    public async Task GetManifestDigestAsync_RateLimited_Throws()
+    {
+        GhcrRegistryClient client = CreateClient(_ => RegistryResponses.TooManyRequests());
+
+        Func<Task> act = () => client.GetManifestDigestAsync("owner/repo", "latest", "amd64");
+
+        await act.Should().ThrowAsync<RegistryRateLimitException>();
+    }
+
+    [Fact]
+    public async Task GetManifestDigestAndCreatedAtAsync_SingleArch_ReturnsDigestAndCreatedAt()
+    {
+        GhcrRegistryClient client = CreateClient(req =>
+        {
+            string url = req.RequestUri!.ToString();
+            if (url.Contains("/blobs/"))
+                return RegistryResponses.Json(RegistryResponses.ConfigBlobBody("2026-07-08T09:10:11Z"));
+            return RegistryResponses.Manifest(
+                RegistryResponses.ManifestContentType,
+                RegistryResponses.ManifestBody("sha256:cfg"),
+                dockerContentDigest: "sha256:ghcrsingle");
+        });
+
+        (string? digest, DateTime? createdAt) =
+            await client.GetManifestDigestAndCreatedAtAsync("owner/repo", "latest", "amd64");
+
+        digest.Should().Be("sha256:ghcrsingle");
+        createdAt.Should().Be(new DateTime(2026, 7, 8, 9, 10, 11, DateTimeKind.Utc).ToLocalTime());
+    }
+}

--- a/lighthouse-back/lighthouse-back.Tests/Services/Registry/IntegrationFactAttribute.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/Registry/IntegrationFactAttribute.cs
@@ -1,0 +1,18 @@
+namespace Lighthouse.Tests.Services.Registry;
+
+/// <summary>
+/// A <see cref="FactAttribute"/> that only runs when the environment variable
+/// <c>RUN_REGISTRY_INTEGRATION=1</c> is set. These tests hit real container registries over the
+/// network, so they are skipped by default (including in CI) and run on demand:
+/// <code>RUN_REGISTRY_INTEGRATION=1 dotnet test --filter Category=RegistryIntegration</code>
+/// </summary>
+public sealed class IntegrationFactAttribute : FactAttribute
+{
+    public IntegrationFactAttribute()
+    {
+        if (Environment.GetEnvironmentVariable("RUN_REGISTRY_INTEGRATION") != "1")
+        {
+            Skip = "Set RUN_REGISTRY_INTEGRATION=1 to run (hits real container registries over the network).";
+        }
+    }
+}

--- a/lighthouse-back/lighthouse-back.Tests/Services/Registry/README.md
+++ b/lighthouse-back/lighthouse-back.Tests/Services/Registry/README.md
@@ -1,0 +1,41 @@
+# Registry client tests
+
+Two kinds of tests live here:
+
+| File | Network? | Runs in CI? |
+|------|----------|-------------|
+| `*RegistryClientTests.cs` (characterization, via `FakeHttpMessageHandler`) | No (mocked) | Yes — part of the normal suite |
+| `RegistryClientsIntegrationTests.cs` | Yes — hits real public registries | **No** — skipped unless opted in |
+
+The integration tests are gated by `[IntegrationFact]`, which skips them unless the
+environment variable `RUN_REGISTRY_INTEGRATION=1` is set. So a normal `dotnet test`
+reports them as *skipped* and CI never touches the network.
+
+## Run the integration tests on demand
+
+From the solution root (`lighthouse-back/`):
+
+```bash
+# Linux / macOS
+RUN_REGISTRY_INTEGRATION=1 dotnet test --filter Category=RegistryIntegration
+```
+
+```powershell
+# Windows (PowerShell)
+$env:RUN_REGISTRY_INTEGRATION = "1"; dotnet test --filter Category=RegistryIntegration
+```
+
+Add `--logger "console;verbosity=detailed"` to print the resolved digests and
+creation dates for each image.
+
+They check that Docker Hub, GHCR and a generic OCI registry (MCR) each resolve a
+`sha256:` digest for a known public image, that the HEAD and GET paths agree (the
+invariant the image-update check relies on), and that a creation date is returned.
+If an image/tag used here is ever retired, update the references in
+`RegistryClientsIntegrationTests.cs`.
+
+## Run only the (fast, offline) characterization tests
+
+```bash
+dotnet test --filter "FullyQualifiedName~RegistryClientTests"
+```

--- a/lighthouse-back/lighthouse-back.Tests/Services/Registry/RegistryClientsIntegrationTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/Registry/RegistryClientsIntegrationTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using Lighthouse.Configuration;
+using Lighthouse.Services;
+using Lighthouse.Services.Registry;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit.Abstractions;
+
+namespace Lighthouse.Tests.Services.Registry;
+
+/// <summary>
+/// End-to-end checks of the registry clients against the real public registries. Skipped unless
+/// RUN_REGISTRY_INTEGRATION=1 (see <see cref="IntegrationFactAttribute"/>). They validate that the
+/// real auth + manifest-parsing flow resolves a digest (and creation date) for a known public image
+/// after the RegistryClientBase refactor — i.e. the part the mocked characterization tests cannot cover.
+/// </summary>
+[Trait("Category", "RegistryIntegration")]
+public class RegistryClientsIntegrationTests
+{
+    private const string Architecture = "amd64";
+
+    private readonly ITestOutputHelper _output;
+
+    public RegistryClientsIntegrationTests(ITestOutputHelper output) => _output = output;
+
+    private static IOptions<UpdateCheckOptions> Options()
+        => Microsoft.Extensions.Options.Options.Create(new UpdateCheckOptions { TimeoutSeconds = 30 });
+
+    private static DockerHubRegistryClient DockerHub()
+    {
+        // No stored Docker Hub credentials → anonymous token (enough for public images).
+        var credentials = new Mock<IRegistryCredentialService>();
+        credentials.Setup(c => c.GetRawCredentialsAsync(It.IsAny<string>()))
+            .ReturnsAsync(((string Username, string Password)?)null);
+        return new DockerHubRegistryClient(new HttpClient(), Options(), credentials.Object,
+            new NullLogger<DockerHubRegistryClient>());
+    }
+
+    private static GhcrRegistryClient Ghcr()
+        => new(new HttpClient(), Options(), new ConfigurationBuilder().Build(),
+            new NullLogger<GhcrRegistryClient>());
+
+    private static GenericOciRegistryClient Generic()
+        => new(new HttpClient(), Options(), new NullLogger<GenericOciRegistryClient>());
+
+    private async Task AssertResolvesAsync(IRegistryClient client, string repositoryOrImage, string tag)
+    {
+        string? headDigest = await client.GetManifestDigestAsync(repositoryOrImage, tag, Architecture);
+        (string? getDigest, DateTime? createdAt) =
+            await client.GetManifestDigestAndCreatedAtAsync(repositoryOrImage, tag, Architecture);
+
+        _output.WriteLine($"{repositoryOrImage}:{tag}");
+        _output.WriteLine($"  HEAD digest : {headDigest}");
+        _output.WriteLine($"  GET  digest : {getDigest}");
+        _output.WriteLine($"  created at  : {createdAt:O}");
+
+        headDigest.Should().StartWith("sha256:");
+        getDigest.Should().StartWith("sha256:");
+        // HEAD and GET resolve the same content-addressable digest for the same tag.
+        headDigest.Should().Be(getDigest);
+        createdAt.Should().NotBeNull();
+    }
+
+    [IntegrationFact]
+    public async Task DockerHub_ResolvesDigestForLibraryNginx()
+        => await AssertResolvesAsync(DockerHub(), "library/nginx", "latest");
+
+    [IntegrationFact]
+    public async Task Ghcr_ResolvesDigestForPublicImage()
+        => await AssertResolvesAsync(Ghcr(), "home-assistant/home-assistant", "stable");
+
+    [IntegrationFact]
+    public async Task GenericOci_ResolvesDigestForMcr()
+        => await AssertResolvesAsync(Generic(), "mcr.microsoft.com/dotnet/aspnet", "10.0-noble");
+}

--- a/lighthouse-back/lighthouse-back/src/Services/Registry/DockerHubRegistryClient.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/Registry/DockerHubRegistryClient.cs
@@ -11,11 +11,8 @@ namespace Lighthouse.Services.Registry;
 /// <summary>
 /// Registry client for Docker Hub (docker.io / registry.hub.docker.com).
 /// </summary>
-public class DockerHubRegistryClient : IRegistryClient
+public class DockerHubRegistryClient : RegistryClientBase
 {
-    private readonly HttpClient _httpClient;
-    private readonly ILogger<DockerHubRegistryClient> _logger;
-    private readonly UpdateCheckOptions _options;
     private readonly IRegistryCredentialService _credentialService;
 
     private const string AuthUrl = "https://auth.docker.io/token";
@@ -27,16 +24,12 @@ public class DockerHubRegistryClient : IRegistryClient
         IOptions<UpdateCheckOptions> options,
         IRegistryCredentialService credentialService,
         ILogger<DockerHubRegistryClient> logger)
+        : base(httpClient, logger, options.Value.TimeoutSeconds)
     {
-        _httpClient = httpClient;
-        _options = options.Value;
         _credentialService = credentialService;
-        _logger = logger;
-
-        _httpClient.Timeout = TimeSpan.FromSeconds(_options.TimeoutSeconds);
     }
 
-    public bool CanHandle(string registry)
+    public override bool CanHandle(string registry)
     {
         return registry == "docker.io" ||
                registry == "registry-1.docker.io" ||
@@ -44,7 +37,7 @@ public class DockerHubRegistryClient : IRegistryClient
                registry == "index.docker.io";
     }
 
-    public async Task<string?> GetManifestDigestAsync(
+    public override async Task<string?> GetManifestDigestAsync(
         string image,
         string tag,
         string architecture,
@@ -55,7 +48,7 @@ public class DockerHubRegistryClient : IRegistryClient
             string? token = await GetAuthTokenAsync(image, cancellationToken);
             if (token == null)
             {
-                _logger.LogWarning("Failed to get auth token for image {Image}", image);
+                Logger.LogWarning("Failed to get auth token for image {Image}", image);
                 return null;
             }
 
@@ -67,7 +60,7 @@ public class DockerHubRegistryClient : IRegistryClient
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting manifest digest (HEAD) for {Image}:{Tag}", image, tag);
+            Logger.LogError(ex, "Error getting manifest digest (HEAD) for {Image}:{Tag}", image, tag);
             return null;
         }
     }
@@ -88,12 +81,9 @@ public class DockerHubRegistryClient : IRegistryClient
 
         using HttpRequestMessage request = new(HttpMethod.Head, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.list.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.index.v1+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
+        AddManifestAcceptHeaders(request);
 
-        HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+        HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken);
 
         if (response.StatusCode == HttpStatusCode.TooManyRequests)
         {
@@ -104,7 +94,7 @@ public class DockerHubRegistryClient : IRegistryClient
         // Some registries don't allow HEAD on manifests → fall back to the GET path.
         if (response.StatusCode is HttpStatusCode.MethodNotAllowed or HttpStatusCode.NotImplemented)
         {
-            _logger.LogDebug("HEAD not supported for {Repository}:{Tag} ({StatusCode}); falling back to GET",
+            Logger.LogDebug("HEAD not supported for {Repository}:{Tag} ({StatusCode}); falling back to GET",
                 repository, tag, response.StatusCode);
             var (fallbackDigest, _) = await FetchManifestDigestAndConfigAsync(repository, tag, architecture, token, cancellationToken);
             return fallbackDigest;
@@ -112,7 +102,7 @@ public class DockerHubRegistryClient : IRegistryClient
 
         if (!response.IsSuccessStatusCode)
         {
-            _logger.LogWarning("Manifest HEAD request failed for {Repository}:{Tag} with status {StatusCode}",
+            Logger.LogWarning("Manifest HEAD request failed for {Repository}:{Tag} with status {StatusCode}",
                 repository, tag, response.StatusCode);
             return null;
         }
@@ -130,7 +120,7 @@ public class DockerHubRegistryClient : IRegistryClient
         return digest;
     }
 
-    public async Task<(string? Digest, DateTime? CreatedAt)> GetManifestDigestAndCreatedAtAsync(
+    public override async Task<(string? Digest, DateTime? CreatedAt)> GetManifestDigestAndCreatedAtAsync(
         string image,
         string tag,
         string architecture,
@@ -138,15 +128,13 @@ public class DockerHubRegistryClient : IRegistryClient
     {
         try
         {
-            // Get authentication token
             string? token = await GetAuthTokenAsync(image, cancellationToken);
             if (token == null)
             {
-                _logger.LogWarning("Failed to get auth token for image {Image}", image);
+                Logger.LogWarning("Failed to get auth token for image {Image}", image);
                 return (null, null);
             }
 
-            // Fetch manifest and get digest + config digest
             var (digest, configDigest) = await FetchManifestDigestAndConfigAsync(image, tag, architecture, token, cancellationToken);
 
             if (digest == null)
@@ -154,11 +142,10 @@ public class DockerHubRegistryClient : IRegistryClient
                 return (null, null);
             }
 
-            // Fetch creation date from config blob
             DateTime? createdAt = null;
             if (configDigest != null)
             {
-                createdAt = await FetchConfigCreatedAtAsync(image, configDigest, token, cancellationToken);
+                createdAt = await FetchConfigCreatedAtAsync(RegistryUrl, image, configDigest, token, cancellationToken);
             }
 
             return (digest, createdAt);
@@ -169,7 +156,7 @@ public class DockerHubRegistryClient : IRegistryClient
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting manifest digest for {Image}:{Tag}", image, tag);
+            Logger.LogError(ex, "Error getting manifest digest for {Image}:{Tag}", image, tag);
             return (null, null);
         }
     }
@@ -191,17 +178,17 @@ public class DockerHubRegistryClient : IRegistryClient
                 string basicAuth = Convert.ToBase64String(
                     Encoding.UTF8.GetBytes($"{credentials.Value.Username}:{credentials.Value.Password}"));
                 tokenRequest.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicAuth);
-                _logger.LogDebug("Using authenticated Docker Hub token request for {Repository} (user: {User})",
+                Logger.LogDebug("Using authenticated Docker Hub token request for {Repository} (user: {User})",
                     repository, credentials.Value.Username);
             }
             else
             {
-                _logger.LogDebug(
+                Logger.LogDebug(
                     "No Docker Hub credentials resolved for {Repository}; using anonymous token (guest rate limits apply)",
                     repository);
             }
 
-            HttpResponseMessage response = await _httpClient.SendAsync(tokenRequest, cancellationToken);
+            HttpResponseMessage response = await HttpClient.SendAsync(tokenRequest, cancellationToken);
 
             if (response.StatusCode == HttpStatusCode.TooManyRequests)
             {
@@ -210,7 +197,7 @@ public class DockerHubRegistryClient : IRegistryClient
 
             if (!response.IsSuccessStatusCode)
             {
-                _logger.LogWarning("Auth token request failed with status {StatusCode}", response.StatusCode);
+                Logger.LogWarning("Auth token request failed with status {StatusCode}", response.StatusCode);
                 return null;
             }
 
@@ -230,7 +217,7 @@ public class DockerHubRegistryClient : IRegistryClient
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to get Docker Hub auth token for {Repository}", repository);
+            Logger.LogError(ex, "Failed to get Docker Hub auth token for {Repository}", repository);
             return null;
         }
     }
@@ -246,14 +233,9 @@ public class DockerHubRegistryClient : IRegistryClient
 
         using HttpRequestMessage request = new(HttpMethod.Get, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        AddManifestAcceptHeaders(request);
 
-        // Accept manifest list (multi-arch) and single manifest types
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.list.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.index.v1+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
-
-        HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+        HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken);
 
         if (response.StatusCode == HttpStatusCode.TooManyRequests)
         {
@@ -263,7 +245,7 @@ public class DockerHubRegistryClient : IRegistryClient
 
         if (!response.IsSuccessStatusCode)
         {
-            _logger.LogWarning("Manifest request failed for {Repository}:{Tag} with status {StatusCode}",
+            Logger.LogWarning("Manifest request failed for {Repository}:{Tag} with status {StatusCode}",
                 repository, tag, response.StatusCode);
             return (null, null);
         }
@@ -273,28 +255,25 @@ public class DockerHubRegistryClient : IRegistryClient
         string contentType = response.Content.Headers.ContentType?.MediaType ?? "";
         string content = await response.Content.ReadAsStringAsync(cancellationToken);
 
-        // Get the digest from Docker-Content-Digest header - this is what Docker stores locally
-        // For multi-arch images, this is the manifest list digest
-        // For single-arch images, this is the manifest digest
+        // Get the digest from Docker-Content-Digest header - this is what Docker stores locally.
+        // For multi-arch images this is the manifest list digest; for single-arch the manifest digest.
         string? digest = null;
         if (response.Headers.TryGetValues("Docker-Content-Digest", out IEnumerable<string>? digestValues))
         {
             digest = digestValues.FirstOrDefault();
         }
 
-        // Check if it's a manifest list (multi-arch)
         if (contentType.Contains("manifest.list") || contentType.Contains("image.index"))
         {
-            // For multi-arch, we use the manifest list digest (from header above) for comparison
-            // But we need to fetch the architecture-specific manifest to get the config for creation date
+            // For multi-arch we use the manifest list digest (from header) for comparison, but fetch
+            // the architecture-specific manifest to get the config digest for the creation date.
             string? archManifestDigest = ExtractDigestFromManifestList(content, architecture);
             if (archManifestDigest == null)
             {
                 return (digest, null);
             }
 
-            // Fetch the architecture-specific manifest to get config digest
-            string? configDigest = await FetchConfigDigestFromManifestAsync(repository, archManifestDigest, token, cancellationToken);
+            string? configDigest = await FetchConfigDigestFromManifestAsync(RegistryUrl, repository, archManifestDigest, token, cancellationToken);
             return (digest, configDigest);
         }
 
@@ -302,163 +281,6 @@ public class DockerHubRegistryClient : IRegistryClient
         string? singleConfigDigest = ExtractConfigDigestFromManifest(content);
 
         return (digest, singleConfigDigest);
-    }
-
-    private async Task<string?> FetchConfigDigestFromManifestAsync(
-        string repository,
-        string manifestDigest,
-        string token,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            string url = $"{RegistryUrl}/{repository}/manifests/{manifestDigest}";
-
-            using HttpRequestMessage request = new(HttpMethod.Get, url);
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
-            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
-
-            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                return null;
-            }
-
-            string content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return ExtractConfigDigestFromManifest(content);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed to fetch config digest from manifest {Digest}", manifestDigest);
-            return null;
-        }
-    }
-
-    private string? ExtractConfigDigestFromManifest(string manifestJson)
-    {
-        try
-        {
-            using JsonDocument doc = JsonDocument.Parse(manifestJson);
-
-            if (doc.RootElement.TryGetProperty("config", out JsonElement config) &&
-                config.TryGetProperty("digest", out JsonElement digestElement))
-            {
-                return digestElement.GetString();
-            }
-
-            return null;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private async Task<DateTime?> FetchConfigCreatedAtAsync(
-        string repository,
-        string configDigest,
-        string token,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            string url = $"{RegistryUrl}/{repository}/blobs/{configDigest}";
-
-            using HttpRequestMessage request = new(HttpMethod.Get, url);
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogDebug("Failed to fetch config blob {ConfigDigest}", configDigest);
-                return null;
-            }
-
-            string content = await response.Content.ReadAsStringAsync(cancellationToken);
-            using JsonDocument doc = JsonDocument.Parse(content);
-
-            if (doc.RootElement.TryGetProperty("created", out JsonElement createdElement))
-            {
-                string? createdStr = createdElement.GetString();
-                if (!string.IsNullOrEmpty(createdStr) && DateTime.TryParse(createdStr, out DateTime created))
-                {
-                    return created;
-                }
-            }
-
-            return null;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed to fetch config created date for {ConfigDigest}", configDigest);
-            return null;
-        }
-    }
-
-    private string? ExtractDigestFromManifestList(string manifestListJson, string architecture)
-    {
-        try
-        {
-            using JsonDocument doc = JsonDocument.Parse(manifestListJson);
-
-            if (!doc.RootElement.TryGetProperty("manifests", out JsonElement manifests))
-            {
-                return null;
-            }
-
-            foreach (JsonElement manifest in manifests.EnumerateArray())
-            {
-                if (!manifest.TryGetProperty("platform", out JsonElement platform))
-                    continue;
-
-                string? arch = platform.TryGetProperty("architecture", out JsonElement archElement)
-                    ? archElement.GetString()
-                    : null;
-
-                string? os = platform.TryGetProperty("os", out JsonElement osElement)
-                    ? osElement.GetString()
-                    : null;
-
-                // Match architecture and OS (default to linux)
-                if (arch == architecture && (os == "linux" || os == null))
-                {
-                    if (manifest.TryGetProperty("digest", out JsonElement digestElement))
-                    {
-                        return digestElement.GetString();
-                    }
-                }
-            }
-
-            // If no exact match, try to find any linux manifest for the architecture
-            foreach (JsonElement manifest in manifests.EnumerateArray())
-            {
-                if (!manifest.TryGetProperty("platform", out JsonElement platform))
-                    continue;
-
-                string? arch = platform.TryGetProperty("architecture", out JsonElement archElement)
-                    ? archElement.GetString()
-                    : null;
-
-                if (arch == architecture)
-                {
-                    if (manifest.TryGetProperty("digest", out JsonElement digestElement))
-                    {
-                        return digestElement.GetString();
-                    }
-                }
-            }
-
-            _logger.LogDebug("No manifest found for architecture {Architecture}", architecture);
-            return null;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error parsing manifest list");
-            return null;
-        }
     }
 
     // Throttle for the low-remaining warning, shared across concurrent checks (UtcTicks; 0 = never).
@@ -480,7 +302,7 @@ public class DockerHubRegistryClient : IRegistryClient
         if (limit == null && remaining == null)
         {
             // No rate-limit headers → either a Pro/Team (unlimited) account or the registry didn't report.
-            _logger.LogDebug(
+            Logger.LogDebug(
                 "Docker Hub rate limit for {Repository}:{Tag} ({Phase}): no rate-limit headers (unlimited/Pro or not reported)",
                 repository, tag, phase);
             return;
@@ -494,7 +316,7 @@ public class DockerHubRegistryClient : IRegistryClient
             _ => "authenticated"
         };
 
-        _logger.LogDebug(
+        Logger.LogDebug(
             "Docker Hub rate limit for {Repository}:{Tag} ({Phase}): tier={Tier}, limit={Limit}, remaining={Remaining}, source={Source}",
             repository, tag, phase, tier, limit ?? "n/a", remaining ?? "n/a", source ?? "n/a");
 
@@ -518,7 +340,7 @@ public class DockerHubRegistryClient : IRegistryClient
             return; // another thread already warned
         }
 
-        _logger.LogWarning(
+        Logger.LogWarning(
             "Docker Hub pull quota nearly exhausted: {Remaining} of {Limit} remaining ({Tier}). " +
             "Authenticate with a Docker Hub account in Registry Management (or raise the check interval) to avoid 429s.",
             remaining, limit?.ToString() ?? "?", tier);

--- a/lighthouse-back/lighthouse-back/src/Services/Registry/GenericOciRegistryClient.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/Registry/GenericOciRegistryClient.cs
@@ -10,31 +10,23 @@ namespace Lighthouse.Services.Registry;
 /// Generic registry client for OCI-compliant registries.
 /// Used as a fallback for registries without specific implementations.
 /// </summary>
-public class GenericOciRegistryClient : IRegistryClient
+public class GenericOciRegistryClient : RegistryClientBase
 {
-    private readonly HttpClient _httpClient;
-    private readonly ILogger<GenericOciRegistryClient> _logger;
-    private readonly UpdateCheckOptions _options;
-
     public GenericOciRegistryClient(
         HttpClient httpClient,
         IOptions<UpdateCheckOptions> options,
         ILogger<GenericOciRegistryClient> logger)
+        : base(httpClient, logger, options.Value.TimeoutSeconds)
     {
-        _httpClient = httpClient;
-        _options = options.Value;
-        _logger = logger;
-
-        _httpClient.Timeout = TimeSpan.FromSeconds(_options.TimeoutSeconds);
     }
 
-    public bool CanHandle(string registry)
+    public override bool CanHandle(string registry)
     {
         // This is the fallback client, so it can handle any registry
         return true;
     }
 
-    public async Task<string?> GetManifestDigestAsync(
+    public override async Task<string?> GetManifestDigestAsync(
         string image,
         string tag,
         string architecture,
@@ -69,7 +61,7 @@ public class GenericOciRegistryClient : IRegistryClient
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting manifest digest (HEAD) for {Image}:{Tag}", image, tag);
+            Logger.LogError(ex, "Error getting manifest digest (HEAD) for {Image}:{Tag}", image, tag);
             return null;
         }
     }
@@ -86,13 +78,7 @@ public class GenericOciRegistryClient : IRegistryClient
         string? token,
         CancellationToken cancellationToken)
     {
-        // Remove tag from repository if present
-        int colonIndex = repository.LastIndexOf(':');
-        if (colonIndex > 0 && !repository.Substring(colonIndex).Contains('/'))
-        {
-            repository = repository.Substring(0, colonIndex);
-        }
-
+        repository = StripTag(repository);
         string url = $"{registryUrl}/{repository}/manifests/{tag}";
 
         using HttpRequestMessage request = new(HttpMethod.Head, url);
@@ -100,14 +86,11 @@ public class GenericOciRegistryClient : IRegistryClient
         {
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         }
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.list.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.index.v1+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
+        AddManifestAcceptHeaders(request);
 
         try
         {
-            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+            HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken);
 
             if (response.StatusCode == HttpStatusCode.TooManyRequests)
             {
@@ -124,7 +107,7 @@ public class GenericOciRegistryClient : IRegistryClient
 
             if (!response.IsSuccessStatusCode)
             {
-                _logger.LogDebug("Manifest HEAD request failed for {Url} with status {StatusCode}", url, response.StatusCode);
+                Logger.LogDebug("Manifest HEAD request failed for {Url} with status {StatusCode}", url, response.StatusCode);
                 return null;
             }
 
@@ -140,12 +123,12 @@ public class GenericOciRegistryClient : IRegistryClient
         }
         catch (HttpRequestException ex)
         {
-            _logger.LogDebug(ex, "HTTP HEAD request failed for {Url}", url);
+            Logger.LogDebug(ex, "HTTP HEAD request failed for {Url}", url);
             return null;
         }
     }
 
-    public async Task<(string? Digest, DateTime? CreatedAt)> GetManifestDigestAndCreatedAtAsync(
+    public override async Task<(string? Digest, DateTime? CreatedAt)> GetManifestDigestAndCreatedAtAsync(
         string image,
         string tag,
         string architecture,
@@ -167,7 +150,7 @@ public class GenericOciRegistryClient : IRegistryClient
             }
 
             // If that fails, try to get a token via WWW-Authenticate challenge
-            _logger.LogDebug("Anonymous access failed for {Registry}/{Repository}, attempting token auth", registry, repository);
+            Logger.LogDebug("Anonymous access failed for {Registry}/{Repository}, attempting token auth", registry, repository);
 
             string? token = await GetTokenViaWwwAuthenticateAsync(
                 registryUrl, repository, cancellationToken);
@@ -186,7 +169,7 @@ public class GenericOciRegistryClient : IRegistryClient
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting manifest digest for {Image}:{Tag}", image, tag);
+            Logger.LogError(ex, "Error getting manifest digest for {Image}:{Tag}", image, tag);
             return (null, null);
         }
     }
@@ -226,69 +209,15 @@ public class GenericOciRegistryClient : IRegistryClient
         return image;
     }
 
-    private async Task<string?> TryFetchManifestAsync(
-        string registryUrl,
-        string repository,
-        string tag,
-        string architecture,
-        string? token,
-        CancellationToken cancellationToken)
+    /// <summary>Removes a trailing <c>:tag</c> from a repository segment, if present.</summary>
+    private static string StripTag(string repository)
     {
-        // Remove tag from repository if present
         int colonIndex = repository.LastIndexOf(':');
         if (colonIndex > 0 && !repository.Substring(colonIndex).Contains('/'))
         {
-            repository = repository.Substring(0, colonIndex);
+            return repository.Substring(0, colonIndex);
         }
-
-        string url = $"{registryUrl}/{repository}/manifests/{tag}";
-
-        using HttpRequestMessage request = new(HttpMethod.Get, url);
-
-        if (!string.IsNullOrEmpty(token))
-        {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-        }
-
-        // Accept manifest list and single manifest types
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.list.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.index.v1+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
-
-        try
-        {
-            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogDebug("Manifest request failed for {Url} with status {StatusCode}",
-                    url, response.StatusCode);
-                return null;
-            }
-
-            string contentType = response.Content.Headers.ContentType?.MediaType ?? "";
-            string content = await response.Content.ReadAsStringAsync(cancellationToken);
-
-            // Check if it's a manifest list
-            if (contentType.Contains("manifest.list") || contentType.Contains("image.index"))
-            {
-                return ExtractDigestFromManifestList(content, architecture);
-            }
-
-            // Single manifest - get digest from header
-            if (response.Headers.TryGetValues("Docker-Content-Digest", out IEnumerable<string>? digestValues))
-            {
-                return digestValues.FirstOrDefault();
-            }
-
-            return null;
-        }
-        catch (HttpRequestException ex)
-        {
-            _logger.LogDebug(ex, "HTTP request failed for {Url}", url);
-            return null;
-        }
+        return repository;
     }
 
     private async Task<string?> GetTokenViaWwwAuthenticateAsync(
@@ -302,9 +231,9 @@ public class GenericOciRegistryClient : IRegistryClient
             string url = $"{registryUrl}/{repository}/manifests/latest";
 
             using HttpRequestMessage request = new(HttpMethod.Get, url);
-            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+            HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken);
 
-            if (response.StatusCode != System.Net.HttpStatusCode.Unauthorized)
+            if (response.StatusCode != HttpStatusCode.Unauthorized)
             {
                 return null;
             }
@@ -320,7 +249,6 @@ public class GenericOciRegistryClient : IRegistryClient
                 return null;
             }
 
-            // Parse bearer parameters
             var parameters = ParseBearerParameters(authHeader);
 
             if (!parameters.TryGetValue("realm", out string? realm))
@@ -351,8 +279,7 @@ public class GenericOciRegistryClient : IRegistryClient
                 tokenUrl += (tokenUrl.Contains('?') ? '&' : '?') + string.Join('&', queryParams);
             }
 
-            // Request token
-            HttpResponseMessage tokenResponse = await _httpClient.GetAsync(tokenUrl, cancellationToken);
+            HttpResponseMessage tokenResponse = await HttpClient.GetAsync(tokenUrl, cancellationToken);
 
             if (!tokenResponse.IsSuccessStatusCode)
             {
@@ -376,86 +303,7 @@ public class GenericOciRegistryClient : IRegistryClient
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to get token via WWW-Authenticate");
-            return null;
-        }
-    }
-
-    private Dictionary<string, string> ParseBearerParameters(string authHeader)
-    {
-        var result = new Dictionary<string, string>();
-
-        // Remove "Bearer " prefix
-        string parameters = authHeader.Substring(7);
-
-        // Parse key="value" pairs
-        var regex = new System.Text.RegularExpressions.Regex(@"(\w+)=""([^""]*)""");
-        foreach (System.Text.RegularExpressions.Match match in regex.Matches(parameters))
-        {
-            result[match.Groups[1].Value] = match.Groups[2].Value;
-        }
-
-        return result;
-    }
-
-    private string? ExtractDigestFromManifestList(string manifestListJson, string architecture)
-    {
-        try
-        {
-            using JsonDocument doc = JsonDocument.Parse(manifestListJson);
-
-            if (!doc.RootElement.TryGetProperty("manifests", out JsonElement manifests))
-            {
-                return null;
-            }
-
-            // First pass: exact match for architecture and linux
-            foreach (JsonElement manifest in manifests.EnumerateArray())
-            {
-                if (!manifest.TryGetProperty("platform", out JsonElement platform))
-                    continue;
-
-                string? arch = platform.TryGetProperty("architecture", out JsonElement archElement)
-                    ? archElement.GetString()
-                    : null;
-
-                string? os = platform.TryGetProperty("os", out JsonElement osElement)
-                    ? osElement.GetString()
-                    : null;
-
-                if (arch == architecture && (os == "linux" || os == null))
-                {
-                    if (manifest.TryGetProperty("digest", out JsonElement digestElement))
-                    {
-                        return digestElement.GetString();
-                    }
-                }
-            }
-
-            // Second pass: any manifest with matching architecture
-            foreach (JsonElement manifest in manifests.EnumerateArray())
-            {
-                if (!manifest.TryGetProperty("platform", out JsonElement platform))
-                    continue;
-
-                string? arch = platform.TryGetProperty("architecture", out JsonElement archElement)
-                    ? archElement.GetString()
-                    : null;
-
-                if (arch == architecture)
-                {
-                    if (manifest.TryGetProperty("digest", out JsonElement digestElement))
-                    {
-                        return digestElement.GetString();
-                    }
-                }
-            }
-
-            return null;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error parsing manifest list");
+            Logger.LogDebug(ex, "Failed to get token via WWW-Authenticate");
             return null;
         }
     }
@@ -468,30 +316,19 @@ public class GenericOciRegistryClient : IRegistryClient
         string? token,
         CancellationToken cancellationToken)
     {
-        // Remove tag from repository if present
-        int colonIndex = repository.LastIndexOf(':');
-        if (colonIndex > 0 && !repository.Substring(colonIndex).Contains('/'))
-        {
-            repository = repository.Substring(0, colonIndex);
-        }
-
+        repository = StripTag(repository);
         string url = $"{registryUrl}/{repository}/manifests/{tag}";
 
         using HttpRequestMessage request = new(HttpMethod.Get, url);
-
         if (!string.IsNullOrEmpty(token))
         {
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         }
-
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.list.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.index.v1+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
+        AddManifestAcceptHeaders(request);
 
         try
         {
-            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+            HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken);
 
             if (response.StatusCode == HttpStatusCode.TooManyRequests)
             {
@@ -500,7 +337,7 @@ public class GenericOciRegistryClient : IRegistryClient
 
             if (!response.IsSuccessStatusCode)
             {
-                _logger.LogDebug("Manifest request failed for {Url} with status {StatusCode}",
+                Logger.LogDebug("Manifest request failed for {Url} with status {StatusCode}",
                     url, response.StatusCode);
                 return (null, null);
             }
@@ -508,20 +345,18 @@ public class GenericOciRegistryClient : IRegistryClient
             string contentType = response.Content.Headers.ContentType?.MediaType ?? "";
             string content = await response.Content.ReadAsStringAsync(cancellationToken);
 
-            // Get the digest from Docker-Content-Digest header - this is what Docker stores locally
-            // For multi-arch images, this is the manifest list digest
-            // For single-arch images, this is the manifest digest
+            // Get the digest from Docker-Content-Digest header - this is what Docker stores locally.
+            // For multi-arch images this is the manifest list digest; for single-arch the manifest digest.
             string? digest = null;
             if (response.Headers.TryGetValues("Docker-Content-Digest", out IEnumerable<string>? digestValues))
             {
                 digest = digestValues.FirstOrDefault();
             }
 
-            // Check if it's a manifest list
             if (contentType.Contains("manifest.list") || contentType.Contains("image.index"))
             {
-                // For multi-arch, we use the manifest list digest (from header above) for comparison
-                // But we need to fetch the architecture-specific manifest to get the config for creation date
+                // For multi-arch we use the manifest list digest (from header) for comparison, but fetch
+                // the architecture-specific manifest to get the config for the creation date.
                 string? archManifestDigest = ExtractDigestFromManifestList(content, architecture);
                 if (archManifestDigest == null)
                 {
@@ -549,110 +384,8 @@ public class GenericOciRegistryClient : IRegistryClient
         }
         catch (HttpRequestException ex)
         {
-            _logger.LogDebug(ex, "HTTP request failed for {Url}", url);
+            Logger.LogDebug(ex, "HTTP request failed for {Url}", url);
             return (null, null);
-        }
-    }
-
-    private async Task<string?> FetchConfigDigestFromManifestAsync(
-        string registryUrl,
-        string repository,
-        string manifestDigest,
-        string? token,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            string url = $"{registryUrl}/{repository}/manifests/{manifestDigest}";
-
-            using HttpRequestMessage request = new(HttpMethod.Get, url);
-            if (!string.IsNullOrEmpty(token))
-            {
-                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            }
-            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
-            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
-
-            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                return null;
-            }
-
-            string content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return ExtractConfigDigestFromManifest(content);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed to fetch config digest from manifest {Digest}", manifestDigest);
-            return null;
-        }
-    }
-
-    private string? ExtractConfigDigestFromManifest(string manifestJson)
-    {
-        try
-        {
-            using JsonDocument doc = JsonDocument.Parse(manifestJson);
-
-            if (doc.RootElement.TryGetProperty("config", out JsonElement config) &&
-                config.TryGetProperty("digest", out JsonElement digestElement))
-            {
-                return digestElement.GetString();
-            }
-
-            return null;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private async Task<DateTime?> FetchConfigCreatedAtAsync(
-        string registryUrl,
-        string repository,
-        string configDigest,
-        string? token,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            string url = $"{registryUrl}/{repository}/blobs/{configDigest}";
-
-            using HttpRequestMessage request = new(HttpMethod.Get, url);
-            if (!string.IsNullOrEmpty(token))
-            {
-                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            }
-
-            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogDebug("Failed to fetch config blob {ConfigDigest}", configDigest);
-                return null;
-            }
-
-            string content = await response.Content.ReadAsStringAsync(cancellationToken);
-            using JsonDocument doc = JsonDocument.Parse(content);
-
-            if (doc.RootElement.TryGetProperty("created", out JsonElement createdElement))
-            {
-                string? createdStr = createdElement.GetString();
-                if (!string.IsNullOrEmpty(createdStr) && DateTime.TryParse(createdStr, out DateTime created))
-                {
-                    return created;
-                }
-            }
-
-            return null;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed to fetch config created date for {ConfigDigest}", configDigest);
-            return null;
         }
     }
 }

--- a/lighthouse-back/lighthouse-back/src/Services/Registry/GhcrRegistryClient.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/Registry/GhcrRegistryClient.cs
@@ -9,11 +9,8 @@ namespace Lighthouse.Services.Registry;
 /// <summary>
 /// Registry client for GitHub Container Registry (ghcr.io).
 /// </summary>
-public class GhcrRegistryClient : IRegistryClient
+public class GhcrRegistryClient : RegistryClientBase
 {
-    private readonly HttpClient _httpClient;
-    private readonly ILogger<GhcrRegistryClient> _logger;
-    private readonly UpdateCheckOptions _options;
     private readonly IConfiguration _configuration;
 
     private const string RegistryUrl = "https://ghcr.io/v2";
@@ -23,21 +20,17 @@ public class GhcrRegistryClient : IRegistryClient
         IOptions<UpdateCheckOptions> options,
         IConfiguration configuration,
         ILogger<GhcrRegistryClient> logger)
+        : base(httpClient, logger, options.Value.TimeoutSeconds)
     {
-        _httpClient = httpClient;
-        _options = options.Value;
         _configuration = configuration;
-        _logger = logger;
-
-        _httpClient.Timeout = TimeSpan.FromSeconds(_options.TimeoutSeconds);
     }
 
-    public bool CanHandle(string registry)
+    public override bool CanHandle(string registry)
     {
         return registry == "ghcr.io";
     }
 
-    public async Task<string?> GetManifestDigestAsync(
+    public override async Task<string?> GetManifestDigestAsync(
         string image,
         string tag,
         string architecture,
@@ -54,7 +47,7 @@ public class GhcrRegistryClient : IRegistryClient
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting manifest digest (HEAD) for ghcr.io/{Image}:{Tag}", image, tag);
+            Logger.LogError(ex, "Error getting manifest digest (HEAD) for ghcr.io/{Image}:{Tag}", image, tag);
             return null;
         }
     }
@@ -77,12 +70,9 @@ public class GhcrRegistryClient : IRegistryClient
         {
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         }
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.list.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.index.v1+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
+        AddManifestAcceptHeaders(request);
 
-        HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+        HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken);
 
         if (response.StatusCode == HttpStatusCode.TooManyRequests)
         {
@@ -107,7 +97,7 @@ public class GhcrRegistryClient : IRegistryClient
 
         if (!response.IsSuccessStatusCode)
         {
-            _logger.LogWarning("Manifest HEAD request failed for ghcr.io/{Repository}:{Tag} with status {StatusCode}",
+            Logger.LogWarning("Manifest HEAD request failed for ghcr.io/{Repository}:{Tag} with status {StatusCode}",
                 repository, tag, response.StatusCode);
             return null;
         }
@@ -132,12 +122,9 @@ public class GhcrRegistryClient : IRegistryClient
 
         using HttpRequestMessage request = new(HttpMethod.Head, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.list.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.index.v1+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
+        AddManifestAcceptHeaders(request);
 
-        HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+        HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken);
 
         if (response.StatusCode == HttpStatusCode.TooManyRequests)
         {
@@ -152,7 +139,7 @@ public class GhcrRegistryClient : IRegistryClient
 
         if (!response.IsSuccessStatusCode)
         {
-            _logger.LogWarning("Manifest HEAD (token) request failed for ghcr.io/{Repository}:{Tag} with status {StatusCode}",
+            Logger.LogWarning("Manifest HEAD (token) request failed for ghcr.io/{Repository}:{Tag} with status {StatusCode}",
                 repository, tag, response.StatusCode);
             return null;
         }
@@ -166,7 +153,7 @@ public class GhcrRegistryClient : IRegistryClient
         return digest;
     }
 
-    public async Task<(string? Digest, DateTime? CreatedAt)> GetManifestDigestAndCreatedAtAsync(
+    public override async Task<(string? Digest, DateTime? CreatedAt)> GetManifestDigestAndCreatedAtAsync(
         string image,
         string tag,
         string architecture,
@@ -185,7 +172,7 @@ public class GhcrRegistryClient : IRegistryClient
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting manifest digest for ghcr.io/{Image}:{Tag}", image, tag);
+            Logger.LogError(ex, "Error getting manifest digest for ghcr.io/{Image}:{Tag}", image, tag);
             return (null, null);
         }
     }
@@ -200,18 +187,13 @@ public class GhcrRegistryClient : IRegistryClient
         string url = $"{RegistryUrl}/{repository}/manifests/{tag}";
 
         using HttpRequestMessage request = new(HttpMethod.Get, url);
-
         if (!string.IsNullOrEmpty(token))
         {
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         }
+        AddManifestAcceptHeaders(request);
 
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.list.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.index.v1+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
-
-        HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+        HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken);
 
         if (response.StatusCode == HttpStatusCode.TooManyRequests)
         {
@@ -230,7 +212,7 @@ public class GhcrRegistryClient : IRegistryClient
 
         if (!response.IsSuccessStatusCode)
         {
-            _logger.LogWarning("Manifest request failed for ghcr.io/{Repository}:{Tag} with status {StatusCode}",
+            Logger.LogWarning("Manifest request failed for ghcr.io/{Repository}:{Tag} with status {StatusCode}",
                 repository, tag, response.StatusCode);
             return (null, null);
         }
@@ -249,13 +231,9 @@ public class GhcrRegistryClient : IRegistryClient
 
         using HttpRequestMessage request = new(HttpMethod.Get, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        AddManifestAcceptHeaders(request);
 
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.list.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.index.v1+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
-
-        HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+        HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken);
 
         if (response.StatusCode == HttpStatusCode.TooManyRequests)
         {
@@ -264,7 +242,7 @@ public class GhcrRegistryClient : IRegistryClient
 
         if (!response.IsSuccessStatusCode)
         {
-            _logger.LogWarning("Manifest request with token failed for ghcr.io/{Repository}:{Tag} with status {StatusCode}",
+            Logger.LogWarning("Manifest request with token failed for ghcr.io/{Repository}:{Tag} with status {StatusCode}",
                 repository, tag, response.StatusCode);
             return (null, null);
         }
@@ -282,9 +260,8 @@ public class GhcrRegistryClient : IRegistryClient
         string contentType = response.Content.Headers.ContentType?.MediaType ?? "";
         string content = await response.Content.ReadAsStringAsync(cancellationToken);
 
-        // Get the digest from Docker-Content-Digest header - this is what Docker stores locally
-        // For multi-arch images, this is the manifest list digest
-        // For single-arch images, this is the manifest digest
+        // The Docker-Content-Digest header is what Docker stores locally: the manifest-list digest for
+        // multi-arch images, or the manifest digest for single-arch images.
         string? digest = null;
         if (response.Headers.TryGetValues("Docker-Content-Digest", out IEnumerable<string>? digestValues))
         {
@@ -293,19 +270,19 @@ public class GhcrRegistryClient : IRegistryClient
 
         if (contentType.Contains("manifest.list") || contentType.Contains("image.index"))
         {
-            // For multi-arch, we use the manifest list digest (from header above) for comparison
-            // But we need to fetch the architecture-specific manifest to get the config for creation date
+            // Use the manifest-list digest (header) for comparison; fetch the per-arch manifest to get
+            // the config blob for the creation date.
             string? archManifestDigest = ExtractDigestFromManifestList(content, architecture);
             if (archManifestDigest == null)
             {
                 return (digest, null);
             }
 
-            string? configDigest = await FetchConfigDigestFromManifestAsync(repository, archManifestDigest, token, cancellationToken);
+            string? configDigest = await FetchConfigDigestFromManifestAsync(RegistryUrl, repository, archManifestDigest, token, cancellationToken);
             DateTime? createdAt = null;
             if (configDigest != null)
             {
-                createdAt = await FetchConfigCreatedAtAsync(repository, configDigest, token, cancellationToken);
+                createdAt = await FetchConfigCreatedAtAsync(RegistryUrl, repository, configDigest, token, cancellationToken);
             }
             return (digest, createdAt);
         }
@@ -315,165 +292,18 @@ public class GhcrRegistryClient : IRegistryClient
         DateTime? singleCreatedAt = null;
         if (singleConfigDigest != null)
         {
-            singleCreatedAt = await FetchConfigCreatedAtAsync(repository, singleConfigDigest, token, cancellationToken);
+            singleCreatedAt = await FetchConfigCreatedAtAsync(RegistryUrl, repository, singleConfigDigest, token, cancellationToken);
         }
 
         return (digest, singleCreatedAt);
     }
 
-    private async Task<string?> FetchConfigDigestFromManifestAsync(
-        string repository,
-        string manifestDigest,
-        string? token,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            string url = $"{RegistryUrl}/{repository}/manifests/{manifestDigest}";
-
-            using HttpRequestMessage request = new(HttpMethod.Get, url);
-            if (!string.IsNullOrEmpty(token))
-            {
-                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            }
-            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
-            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
-
-            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                return null;
-            }
-
-            string content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return ExtractConfigDigestFromManifest(content);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed to fetch config digest from manifest {Digest}", manifestDigest);
-            return null;
-        }
-    }
-
-    private string? ExtractConfigDigestFromManifest(string manifestJson)
-    {
-        try
-        {
-            using JsonDocument doc = JsonDocument.Parse(manifestJson);
-
-            if (doc.RootElement.TryGetProperty("config", out JsonElement config) &&
-                config.TryGetProperty("digest", out JsonElement digestElement))
-            {
-                return digestElement.GetString();
-            }
-
-            return null;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private async Task<DateTime?> FetchConfigCreatedAtAsync(
-        string repository,
-        string configDigest,
-        string? token,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            string url = $"{RegistryUrl}/{repository}/blobs/{configDigest}";
-
-            using HttpRequestMessage request = new(HttpMethod.Get, url);
-            if (!string.IsNullOrEmpty(token))
-            {
-                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            }
-
-            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogDebug("Failed to fetch config blob {ConfigDigest}", configDigest);
-                return null;
-            }
-
-            string content = await response.Content.ReadAsStringAsync(cancellationToken);
-            using JsonDocument doc = JsonDocument.Parse(content);
-
-            if (doc.RootElement.TryGetProperty("created", out JsonElement createdElement))
-            {
-                string? createdStr = createdElement.GetString();
-                if (!string.IsNullOrEmpty(createdStr) && DateTime.TryParse(createdStr, out DateTime created))
-                {
-                    return created;
-                }
-            }
-
-            return null;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed to fetch config created date for {ConfigDigest}", configDigest);
-            return null;
-        }
-    }
-
     private string? GetAuthToken()
     {
-        // Check for GitHub token in configuration
+        // Check for GitHub token in configuration.
         // Can be set via environment variable: GitHub__Token or SelfUpdate__GitHubAccessToken
-        string? token = _configuration["GitHub:Token"]
+        return _configuration["GitHub:Token"]
             ?? _configuration["SelfUpdate:GitHubAccessToken"];
-
-        return token;
-    }
-
-    private async Task<string?> FetchManifestDigestAsync(
-        string repository,
-        string tag,
-        string architecture,
-        string? token,
-        CancellationToken cancellationToken)
-    {
-        string url = $"{RegistryUrl}/{repository}/manifests/{tag}";
-
-        using HttpRequestMessage request = new(HttpMethod.Get, url);
-
-        // Add authorization if we have a token
-        if (!string.IsNullOrEmpty(token))
-        {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-        }
-
-        // Accept manifest list (multi-arch) and single manifest types
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.list.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.index.v1+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
-
-        HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
-
-        if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
-        {
-            // Try to get token from WWW-Authenticate header and retry
-            string? newToken = await HandleUnauthorizedAsync(response, repository, cancellationToken);
-            if (newToken != null)
-            {
-                return await FetchManifestDigestWithTokenAsync(repository, tag, architecture, newToken, cancellationToken);
-            }
-        }
-
-        if (!response.IsSuccessStatusCode)
-        {
-            _logger.LogWarning("Manifest request failed for ghcr.io/{Repository}:{Tag} with status {StatusCode}",
-                repository, tag, response.StatusCode);
-            return null;
-        }
-
-        return await ExtractDigestFromResponseAsync(response, architecture, cancellationToken);
     }
 
     private async Task<string?> HandleUnauthorizedAsync(
@@ -493,7 +323,6 @@ public class GhcrRegistryClient : IRegistryClient
             return null;
         }
 
-        // Parse bearer parameters
         var parameters = ParseBearerParameters(authHeader);
 
         if (!parameters.TryGetValue("realm", out string? realm) ||
@@ -522,7 +351,7 @@ public class GhcrRegistryClient : IRegistryClient
                 tokenRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", ghToken);
             }
 
-            HttpResponseMessage tokenResponse = await _httpClient.SendAsync(tokenRequest, cancellationToken);
+            HttpResponseMessage tokenResponse = await HttpClient.SendAsync(tokenRequest, cancellationToken);
 
             if (!tokenResponse.IsSuccessStatusCode)
             {
@@ -539,139 +368,9 @@ public class GhcrRegistryClient : IRegistryClient
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to get GHCR token");
+            Logger.LogDebug(ex, "Failed to get GHCR token");
         }
 
         return null;
-    }
-
-    private Dictionary<string, string> ParseBearerParameters(string authHeader)
-    {
-        var result = new Dictionary<string, string>();
-
-        // Remove "Bearer " prefix
-        string parameters = authHeader.Substring(7);
-
-        // Parse key="value" pairs
-        var regex = new System.Text.RegularExpressions.Regex(@"(\w+)=""([^""]*)""");
-        foreach (System.Text.RegularExpressions.Match match in regex.Matches(parameters))
-        {
-            result[match.Groups[1].Value] = match.Groups[2].Value;
-        }
-
-        return result;
-    }
-
-    private async Task<string?> FetchManifestDigestWithTokenAsync(
-        string repository,
-        string tag,
-        string architecture,
-        string token,
-        CancellationToken cancellationToken)
-    {
-        string url = $"{RegistryUrl}/{repository}/manifests/{tag}";
-
-        using HttpRequestMessage request = new(HttpMethod.Get, url);
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.list.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.index.v1+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
-
-        HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
-
-        if (!response.IsSuccessStatusCode)
-        {
-            _logger.LogWarning("Manifest request with token failed for ghcr.io/{Repository}:{Tag} with status {StatusCode}",
-                repository, tag, response.StatusCode);
-            return null;
-        }
-
-        return await ExtractDigestFromResponseAsync(response, architecture, cancellationToken);
-    }
-
-    private async Task<string?> ExtractDigestFromResponseAsync(
-        HttpResponseMessage response,
-        string architecture,
-        CancellationToken cancellationToken)
-    {
-        string contentType = response.Content.Headers.ContentType?.MediaType ?? "";
-        string content = await response.Content.ReadAsStringAsync(cancellationToken);
-
-        // Check if it's a manifest list (multi-arch)
-        if (contentType.Contains("manifest.list") || contentType.Contains("image.index"))
-        {
-            return ExtractDigestFromManifestList(content, architecture);
-        }
-
-        // Single manifest - get digest from Docker-Content-Digest header
-        if (response.Headers.TryGetValues("Docker-Content-Digest", out IEnumerable<string>? digestValues))
-        {
-            return digestValues.FirstOrDefault();
-        }
-
-        return null;
-    }
-
-    private string? ExtractDigestFromManifestList(string manifestListJson, string architecture)
-    {
-        try
-        {
-            using JsonDocument doc = JsonDocument.Parse(manifestListJson);
-
-            if (!doc.RootElement.TryGetProperty("manifests", out JsonElement manifests))
-            {
-                return null;
-            }
-
-            foreach (JsonElement manifest in manifests.EnumerateArray())
-            {
-                if (!manifest.TryGetProperty("platform", out JsonElement platform))
-                    continue;
-
-                string? arch = platform.TryGetProperty("architecture", out JsonElement archElement)
-                    ? archElement.GetString()
-                    : null;
-
-                string? os = platform.TryGetProperty("os", out JsonElement osElement)
-                    ? osElement.GetString()
-                    : null;
-
-                if (arch == architecture && (os == "linux" || os == null))
-                {
-                    if (manifest.TryGetProperty("digest", out JsonElement digestElement))
-                    {
-                        return digestElement.GetString();
-                    }
-                }
-            }
-
-            // Fallback: any manifest with matching architecture
-            foreach (JsonElement manifest in manifests.EnumerateArray())
-            {
-                if (!manifest.TryGetProperty("platform", out JsonElement platform))
-                    continue;
-
-                string? arch = platform.TryGetProperty("architecture", out JsonElement archElement)
-                    ? archElement.GetString()
-                    : null;
-
-                if (arch == architecture)
-                {
-                    if (manifest.TryGetProperty("digest", out JsonElement digestElement))
-                    {
-                        return digestElement.GetString();
-                    }
-                }
-            }
-
-            return null;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error parsing GHCR manifest list");
-            return null;
-        }
     }
 }

--- a/lighthouse-back/lighthouse-back/src/Services/Registry/RegistryClientBase.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/Registry/RegistryClientBase.cs
@@ -1,0 +1,230 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Lighthouse.Services.Registry;
+
+/// <summary>
+/// Shared base for the registry clients. Holds the registry-agnostic plumbing — manifest Accept
+/// headers, manifest-list / config-digest parsing, and config-blob created-at lookup — while each
+/// concrete client keeps its own registry-specific authentication and request orchestration.
+/// </summary>
+public abstract class RegistryClientBase : IRegistryClient
+{
+    protected HttpClient HttpClient { get; }
+    protected ILogger Logger { get; }
+
+    protected RegistryClientBase(HttpClient httpClient, ILogger logger, int timeoutSeconds)
+    {
+        HttpClient = httpClient;
+        Logger = logger;
+        HttpClient.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
+    }
+
+    public abstract bool CanHandle(string registry);
+
+    public abstract Task<string?> GetManifestDigestAsync(
+        string image, string tag, string architecture, CancellationToken cancellationToken = default);
+
+    public abstract Task<(string? Digest, DateTime? CreatedAt)> GetManifestDigestAndCreatedAtAsync(
+        string image, string tag, string architecture, CancellationToken cancellationToken = default);
+
+    /// <summary>Adds the manifest-list and single-manifest Accept headers used for digest lookups.</summary>
+    protected static void AddManifestAcceptHeaders(HttpRequestMessage request)
+    {
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.list.v2+json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.index.v1+json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
+    }
+
+    /// <summary>Adds the single-image-manifest Accept headers used when fetching a per-arch manifest.</summary>
+    protected static void AddImageManifestAcceptHeaders(HttpRequestMessage request)
+    {
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
+    }
+
+    /// <summary>Parses <c>key="value"</c> pairs from a <c>Bearer ...</c> WWW-Authenticate header.</summary>
+    protected static Dictionary<string, string> ParseBearerParameters(string authHeader)
+    {
+        var result = new Dictionary<string, string>();
+
+        // Remove "Bearer " prefix
+        string parameters = authHeader.Substring(7);
+
+        var regex = new Regex(@"(\w+)=""([^""]*)""");
+        foreach (Match match in regex.Matches(parameters))
+        {
+            result[match.Groups[1].Value] = match.Groups[2].Value;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Selects the per-architecture manifest digest from a manifest-list / image-index body.
+    /// Prefers an exact arch + linux match, then falls back to any manifest with the architecture.
+    /// </summary>
+    protected string? ExtractDigestFromManifestList(string manifestListJson, string architecture)
+    {
+        try
+        {
+            using JsonDocument doc = JsonDocument.Parse(manifestListJson);
+
+            if (!doc.RootElement.TryGetProperty("manifests", out JsonElement manifests))
+            {
+                return null;
+            }
+
+            // First pass: exact architecture and linux (or unspecified) OS.
+            foreach (JsonElement manifest in manifests.EnumerateArray())
+            {
+                if (!manifest.TryGetProperty("platform", out JsonElement platform))
+                    continue;
+
+                string? arch = platform.TryGetProperty("architecture", out JsonElement archElement)
+                    ? archElement.GetString()
+                    : null;
+                string? os = platform.TryGetProperty("os", out JsonElement osElement)
+                    ? osElement.GetString()
+                    : null;
+
+                if (arch == architecture && (os == "linux" || os == null) &&
+                    manifest.TryGetProperty("digest", out JsonElement digestElement))
+                {
+                    return digestElement.GetString();
+                }
+            }
+
+            // Second pass: any manifest with a matching architecture.
+            foreach (JsonElement manifest in manifests.EnumerateArray())
+            {
+                if (!manifest.TryGetProperty("platform", out JsonElement platform))
+                    continue;
+
+                string? arch = platform.TryGetProperty("architecture", out JsonElement archElement)
+                    ? archElement.GetString()
+                    : null;
+
+                if (arch == architecture &&
+                    manifest.TryGetProperty("digest", out JsonElement digestElement))
+                {
+                    return digestElement.GetString();
+                }
+            }
+
+            Logger.LogDebug("No manifest found for architecture {Architecture}", architecture);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error parsing manifest list");
+            return null;
+        }
+    }
+
+    /// <summary>Extracts the <c>config.digest</c> from a single image manifest body.</summary>
+    protected static string? ExtractConfigDigestFromManifest(string manifestJson)
+    {
+        try
+        {
+            using JsonDocument doc = JsonDocument.Parse(manifestJson);
+
+            if (doc.RootElement.TryGetProperty("config", out JsonElement config) &&
+                config.TryGetProperty("digest", out JsonElement digestElement))
+            {
+                return digestElement.GetString();
+            }
+
+            return null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Fetches a per-arch manifest and returns its config-blob digest.</summary>
+    protected async Task<string?> FetchConfigDigestFromManifestAsync(
+        string registryUrl,
+        string repository,
+        string manifestDigest,
+        string? token,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            string url = $"{registryUrl}/{repository}/manifests/{manifestDigest}";
+
+            using HttpRequestMessage request = new(HttpMethod.Get, url);
+            if (!string.IsNullOrEmpty(token))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
+            AddImageManifestAcceptHeaders(request);
+
+            HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+
+            string content = await response.Content.ReadAsStringAsync(cancellationToken);
+            return ExtractConfigDigestFromManifest(content);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Failed to fetch config digest from manifest {Digest}", manifestDigest);
+            return null;
+        }
+    }
+
+    /// <summary>Reads the <c>created</c> timestamp from a config blob.</summary>
+    protected async Task<DateTime?> FetchConfigCreatedAtAsync(
+        string registryUrl,
+        string repository,
+        string configDigest,
+        string? token,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            string url = $"{registryUrl}/{repository}/blobs/{configDigest}";
+
+            using HttpRequestMessage request = new(HttpMethod.Get, url);
+            if (!string.IsNullOrEmpty(token))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
+
+            HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                Logger.LogDebug("Failed to fetch config blob {ConfigDigest}", configDigest);
+                return null;
+            }
+
+            string content = await response.Content.ReadAsStringAsync(cancellationToken);
+            using JsonDocument doc = JsonDocument.Parse(content);
+
+            if (doc.RootElement.TryGetProperty("created", out JsonElement createdElement))
+            {
+                string? createdStr = createdElement.GetString();
+                if (!string.IsNullOrEmpty(createdStr) && DateTime.TryParse(createdStr, out DateTime created))
+                {
+                    return created;
+                }
+            }
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Failed to fetch config created date for {ConfigDigest}", configDigest);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Second structural tier. Consolidates the three registry clients under a shared base, with a test safety net written **first** so the refactor is provably behavior-preserving.

## Approach (tests-first, per your call)
1. Added characterization tests (`FakeHttpMessageHandler` + 15 tests) pinning the current externally-observable behavior of all three clients: single-arch & multi-arch digest resolution, HEAD→GET fallback, 429 rate-limit, and each registry's token/401 flow. **Green before the refactor.**
2. Extracted `RegistryClientBase` and refactored the clients under those green tests.

## What moved to the base
The registry-agnostic plumbing that was copy-pasted in all three: manifest-list / image-index parsing, `config.digest` extraction, config-blob `created` lookup, bearer-parameter parsing, and the Accept-header setup. Plus the shared `HttpClient`/`Logger` and timeout wiring.

## What stays per-client (genuinely different)
- **Docker Hub** — token-service auth with optional Basic creds + rate-limit-header logging.
- **GHCR** — optional GitHub PAT + 401 WWW-Authenticate challenge.
- **Generic OCI** — anonymous-then-challenge, derives registry/repository from the image ref.

## Also
Removed dead methods with no callers: GHCR `FetchManifestDigestAsync` / `FetchManifestDigestWithTokenAsync` / `ExtractDigestFromResponseAsync`, and Generic `TryFetchManifestAsync`.

## Result
~**−516 lines** across the clients (1877 → 1361 incl. the new base); GHCR alone 677 → 376. Shared logic now lives in one place.

## Verification
- `dotnet build -c Release` → 0 warnings, 0 errors.
- `dotnet test` → **305 passed** (290 + 15 new), characterization tests green pre- and post-refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)