### PR TITLE
refactor: extract ComposeFilesController (PR6, seam 2)

### DIFF
--- a/lighthouse-back/lighthouse-back.Tests/Controllers/ComposeFilesControllerTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Controllers/ComposeFilesControllerTests.cs
@@ -1,0 +1,130 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Lighthouse.Configuration;
+using Lighthouse.Controllers;
+using Lighthouse.DTOs;
+using Lighthouse.Models;
+using Lighthouse.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Lighthouse.Tests.Controllers;
+
+/// <summary>
+/// Behavioural tests for <see cref="ComposeFilesController"/> (extracted from ComposeController in PR6).
+/// Covers the discovery / conflicts / refresh endpoints. The health endpoint depends on the concrete
+/// DockerService (a live daemon) and is exercised by the app-level <c>/health</c> smoke instead.
+/// </summary>
+public class ComposeFilesControllerTests
+{
+    private readonly Mock<IComposeFileCacheService> _cache = new();
+    private readonly Mock<IConflictResolutionService> _conflicts = new();
+    private readonly Mock<ISelfFilterService> _selfFilter = new();
+    private readonly Mock<IAuditService> _audit = new();
+
+    private ComposeFilesController CreateController(bool authenticated)
+    {
+        var controller = new ComposeFilesController(
+            _cache.Object,
+            _conflicts.Object,
+            _selfFilter.Object,
+            _audit.Object,
+            Options.Create(new ComposeDiscoveryOptions()),
+            dockerService: null!, // only used by GetHealth, which these tests don't call
+            new NullLogger<ComposeFilesController>());
+
+        var identity = authenticated
+            ? new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "1") }, "test")
+            : new ClaimsIdentity();
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+        return controller;
+    }
+
+    private static T Payload<T>(ActionResult<ApiResponse<T>> result)
+    {
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        return ok.Value.Should().BeOfType<ApiResponse<T>>().Subject.Data!;
+    }
+
+    private static DiscoveredComposeFile File(string project) => new()
+    {
+        FilePath = $"/c/{project}/docker-compose.yml",
+        ProjectName = project,
+        DirectoryPath = $"/c/{project}",
+        LastModified = DateTime.UtcNow,
+        IsValid = true,
+        IsDisabled = false,
+        Services = new List<string> { "web" }
+    };
+
+    [Fact]
+    public async Task GetDiscoveredFiles_ReturnsMappedFiles()
+    {
+        _cache.Setup(c => c.GetOrScanAsync(false)).ReturnsAsync(new List<DiscoveredComposeFile> { File("a"), File("b") });
+        _selfFilter.Setup(s => s.GetSelfProjectNameAsync()).ReturnsAsync((string?)null);
+        ComposeFilesController controller = CreateController(authenticated: true);
+
+        ActionResult<ApiResponse<List<DiscoveredComposeFileDto>>> result = await controller.GetDiscoveredFiles();
+
+        Payload(result).Select(d => d.ProjectName).Should().BeEquivalentTo("a", "b");
+    }
+
+    [Fact]
+    public async Task GetDiscoveredFiles_FiltersOutSelfProject()
+    {
+        _cache.Setup(c => c.GetOrScanAsync(false)).ReturnsAsync(new List<DiscoveredComposeFile> { File("a"), File("lighthouse") });
+        _selfFilter.Setup(s => s.GetSelfProjectNameAsync()).ReturnsAsync("lighthouse");
+        ComposeFilesController controller = CreateController(authenticated: true);
+
+        ActionResult<ApiResponse<List<DiscoveredComposeFileDto>>> result = await controller.GetDiscoveredFiles();
+
+        Payload(result).Select(d => d.ProjectName).Should().BeEquivalentTo("a");
+    }
+
+    [Fact]
+    public void GetConflicts_ReturnsConflicts()
+    {
+        var conflict = new ConflictErrorDto("dup", new List<string> { "/a", "/b" }, "conflict", new List<string>());
+        _conflicts.Setup(c => c.GetConflictErrors()).Returns(new List<ConflictErrorDto> { conflict });
+        ComposeFilesController controller = CreateController(authenticated: true);
+
+        ActionResult<ApiResponse<ConflictsResponse>> result = controller.GetConflicts();
+
+        ConflictsResponse response = Payload(result);
+        response.HasConflicts.Should().BeTrue();
+        response.Conflicts.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task RefreshComposeFiles_Unauthenticated_ReturnsUnauthorized()
+    {
+        ComposeFilesController controller = CreateController(authenticated: false);
+
+        ActionResult<ApiResponse<object>> result = await controller.RefreshComposeFiles();
+
+        result.Result.Should().BeOfType<UnauthorizedObjectResult>();
+        _cache.Verify(c => c.Invalidate(), Times.Never);
+    }
+
+    [Fact]
+    public async Task RefreshComposeFiles_Authenticated_InvalidatesScansAndAudits()
+    {
+        _cache.Setup(c => c.GetOrScanAsync(true)).ReturnsAsync(new List<DiscoveredComposeFile> { File("a") });
+        ComposeFilesController controller = CreateController(authenticated: true);
+
+        ActionResult<ApiResponse<object>> result = await controller.RefreshComposeFiles();
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        _cache.Verify(c => c.Invalidate(), Times.Once);
+        _cache.Verify(c => c.GetOrScanAsync(true), Times.Once);
+        _audit.Verify(a => a.LogActionAsync(1, "compose.cache_refresh",
+            It.IsAny<string>(), It.IsAny<string>(), "System", "ComposeDiscovery", It.IsAny<object?>(), It.IsAny<object?>()),
+            Times.Once);
+    }
+}

--- a/lighthouse-back/lighthouse-back/src/Controllers/ComposeController.cs
+++ b/lighthouse-back/lighthouse-back/src/Controllers/ComposeController.cs
@@ -28,10 +28,7 @@ public class ComposeController : BaseController
     private readonly IProjectMatchingService _projectMatchingService;
     private readonly IComposeFileCacheService _composeFileCacheService;
     private readonly IImageUpdateCacheService _imageUpdateCacheService;
-    private readonly IConflictResolutionService _conflictService;
     private readonly IPathValidator _pathValidator;
-    private readonly IOptions<ComposeDiscoveryOptions> _composeOptions;
-    private readonly DockerService _dockerService;
     private readonly ISelfFilterService _selfFilterService;
 
     public ComposeController(
@@ -47,10 +44,7 @@ public class ComposeController : BaseController
         IProjectMatchingService projectMatchingService,
         IComposeFileCacheService composeFileCacheService,
         IImageUpdateCacheService imageUpdateCacheService,
-        IConflictResolutionService conflictService,
         IPathValidator pathValidator,
-        IOptions<ComposeDiscoveryOptions> composeOptions,
-        DockerService dockerService,
         ISelfFilterService selfFilterService)
     {
         _context = context;
@@ -65,215 +59,8 @@ public class ComposeController : BaseController
         _projectMatchingService = projectMatchingService;
         _composeFileCacheService = composeFileCacheService;
         _imageUpdateCacheService = imageUpdateCacheService;
-        _conflictService = conflictService;
         _pathValidator = pathValidator;
-        _composeOptions = composeOptions;
-        _dockerService = dockerService;
         _selfFilterService = selfFilterService;
-    }
-
-    // ============================================
-    // Compose Files Discovery Endpoints
-    // ============================================
-
-    /// <summary>
-    /// Lists all discovered compose files from the configured root directory
-    /// </summary>
-    /// <remarks>
-    /// Returns all compose files found during automatic discovery, including:
-    /// - File paths and project names
-    /// - Validity status (YAML parsing)
-    /// - Disabled status (x-disabled flag)
-    /// - Service lists extracted from each file
-    /// </remarks>
-    [HttpGet("files")]
-    public async Task<ActionResult<ApiResponse<List<DiscoveredComposeFileDto>>>> GetDiscoveredFiles()
-    {
-        try
-        {
-            List<DiscoveredComposeFile> files = await _composeFileCacheService.GetOrScanAsync();
-            List<DiscoveredComposeFileDto> dtos = files.Select(f => new DiscoveredComposeFileDto(
-                FilePath: f.FilePath,
-                ProjectName: f.ProjectName,
-                DirectoryPath: f.DirectoryPath,
-                LastModified: f.LastModified,
-                IsValid: f.IsValid,
-                IsDisabled: f.IsDisabled,
-                Services: f.Services
-            )).ToList();
-
-            // Filter out the application's own compose file
-            string? selfProject = await _selfFilterService.GetSelfProjectNameAsync();
-            if (selfProject != null)
-            {
-                dtos = dtos.Where(d => !selfProject.Equals(d.ProjectName, StringComparison.OrdinalIgnoreCase)).ToList();
-            }
-
-            return Ok(ApiResponse.Ok(dtos));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting discovered compose files");
-            return StatusCode(500, ApiResponse.Fail<List<DiscoveredComposeFileDto>>("Error retrieving compose files", "SERVER_ERROR"));
-        }
-    }
-
-    /// <summary>
-    /// Returns detected conflicts between compose files with the same project name
-    /// </summary>
-    /// <remarks>
-    /// Conflicts occur when multiple compose files have the same project name.
-    /// To resolve, add 'x-disabled: true' to unwanted files.
-    /// </remarks>
-    [HttpGet("conflicts")]
-    public ActionResult<ApiResponse<ConflictsResponse>> GetConflicts()
-    {
-        try
-        {
-            List<ConflictErrorDto> conflicts = _conflictService.GetConflictErrors();
-            ConflictsResponse response = new ConflictsResponse(conflicts, conflicts.Any());
-            return Ok(ApiResponse.Ok(response));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting compose conflicts");
-            return StatusCode(500, ApiResponse.Fail<ConflictsResponse>("Error retrieving conflicts", "SERVER_ERROR"));
-        }
-    }
-
-    // ============================================
-    // Health Check Endpoint
-    // ============================================
-
-    /// <summary>
-    /// Gets health status of compose discovery system and Docker daemon
-    /// </summary>
-    /// <returns>Health status information including compose discovery and Docker daemon status</returns>
-    /// <remarks>
-    /// This diagnostic endpoint provides information about:
-    /// - Compose files directory accessibility
-    /// - Docker daemon connection status
-    /// - Overall system health (healthy, degraded, or critical)
-    ///
-    /// The endpoint returns different statuses:
-    /// - "healthy": All systems operational
-    /// - "degraded": Compose discovery unavailable but Docker accessible (can still manage existing projects)
-    /// - "critical": Docker daemon inaccessible (system non-functional)
-    ///
-    /// No authentication required - this is a diagnostic endpoint.
-    /// </remarks>
-    [HttpGet("health")]
-    [AllowAnonymous]
-    public async Task<ActionResult<ApiResponse<ComposeHealthDto>>> GetHealth()
-    {
-        // Check compose discovery directory
-        string rootPath = _composeOptions.Value.RootPath;
-        bool dirExists = Directory.Exists(rootPath);
-        bool dirAccessible = false;
-
-        if (dirExists)
-        {
-            try
-            {
-                Directory.GetFiles(rootPath);
-                dirAccessible = true;
-            }
-            catch
-            {
-                // Directory exists but not accessible
-            }
-        }
-
-        // Check Docker daemon
-        bool dockerConnected = false;
-        string? dockerVersion = null;
-        string? dockerApiVersion = null;
-        string? dockerError = null;
-
-        try
-        {
-            (dockerVersion, dockerApiVersion) = await _dockerService.GetVersionAsync();
-            dockerConnected = true;
-        }
-        catch (Exception ex)
-        {
-            dockerError = ex.Message;
-        }
-
-        // Determine overall status
-        string overallStatus;
-        if (!dockerConnected)
-            overallStatus = "critical"; // Docker inaccessible
-        else if (!dirAccessible)
-            overallStatus = "degraded"; // Directory inaccessible
-        else
-            overallStatus = "healthy";
-
-        ComposeHealthDto healthDto = new ComposeHealthDto(
-            Status: overallStatus,
-            ComposeDiscovery: new ComposeHealthStatusDto(
-                Status: dirAccessible ? "healthy" : "degraded",
-                RootPath: rootPath,
-                Exists: dirExists,
-                Accessible: dirAccessible,
-                DegradedMode: !dirAccessible,
-                Message: dirAccessible ? null : "Compose files directory is not accessible",
-                Impact: dirAccessible ? null : "Only existing Docker projects can be managed. Compose file discovery is disabled."
-            ),
-            DockerDaemon: new DockerDaemonStatusDto(
-                Status: dockerConnected ? "healthy" : "unhealthy",
-                Connected: dockerConnected,
-                Version: dockerVersion,
-                ApiVersion: dockerApiVersion,
-                Error: dockerError
-            )
-        );
-
-        return Ok(ApiResponse.Ok(healthDto));
-    }
-
-    /// <summary>
-    /// Manually refreshes the compose file discovery cache
-    /// </summary>
-    /// <remarks>
-    /// Invalidates the cache and performs a fresh filesystem scan.
-    /// Use this after adding, modifying, or removing compose files.
-    /// </remarks>
-    /// <returns>Scan results with file count and timestamp</returns>
-    [HttpPost("refresh")]
-    [Authorize(Roles = "admin")]
-    public async Task<ActionResult<ApiResponse<object>>> RefreshComposeFiles()
-    {
-        int? userId = GetCurrentUserId();
-        if (!userId.HasValue)
-        {
-            return Unauthorized(ApiResponse.Fail<object>("User not authenticated"));
-        }
-
-        _logger.LogInformation("Admin user {UserId} triggered manual cache refresh", userId.Value);
-
-        // Invalidate cache
-        _composeFileCacheService.Invalidate();
-
-        // Trigger fresh scan
-        List<DiscoveredComposeFile> files = await _composeFileCacheService.GetOrScanAsync(bypassCache: true);
-
-        await _auditService.LogActionAsync(
-            userId.Value,
-            "compose.cache_refresh",
-            GetUserIpAddress(),
-            $"Manual cache refresh triggered, found {files.Count} files",
-            resourceType: "System",
-            resourceId: "ComposeDiscovery"
-        );
-
-        return Ok(ApiResponse.Ok(new
-        {
-            success = true,
-            message = $"Cache refreshed. Found {files.Count} compose files.",
-            filesDiscovered = files.Count,
-            timestamp = DateTime.UtcNow
-        }));
     }
 
     // ============================================

--- a/lighthouse-back/lighthouse-back/src/Controllers/ComposeFilesController.cs
+++ b/lighthouse-back/lighthouse-back/src/Controllers/ComposeFilesController.cs
@@ -1,0 +1,241 @@
+using Lighthouse.Configuration;
+using Lighthouse.DTOs;
+using Lighthouse.Models;
+using Lighthouse.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Lighthouse.Controllers;
+
+/// <summary>
+/// Compose file discovery, conflict and health endpoints. Split out of ComposeController so the
+/// discovery concern stays focused; shares the <c>api/compose</c> route prefix.
+/// </summary>
+[ApiController]
+[Route("api/compose")]
+[Authorize]
+public class ComposeFilesController : BaseController
+{
+    private readonly IComposeFileCacheService _composeFileCacheService;
+    private readonly IConflictResolutionService _conflictService;
+    private readonly ISelfFilterService _selfFilterService;
+    private readonly IAuditService _auditService;
+    private readonly IOptions<ComposeDiscoveryOptions> _composeOptions;
+    private readonly DockerService _dockerService;
+    private readonly ILogger<ComposeFilesController> _logger;
+
+    public ComposeFilesController(
+        IComposeFileCacheService composeFileCacheService,
+        IConflictResolutionService conflictService,
+        ISelfFilterService selfFilterService,
+        IAuditService auditService,
+        IOptions<ComposeDiscoveryOptions> composeOptions,
+        DockerService dockerService,
+        ILogger<ComposeFilesController> logger)
+    {
+        _composeFileCacheService = composeFileCacheService;
+        _conflictService = conflictService;
+        _selfFilterService = selfFilterService;
+        _auditService = auditService;
+        _composeOptions = composeOptions;
+        _dockerService = dockerService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Lists all discovered compose files from the configured root directory
+    /// </summary>
+    /// <remarks>
+    /// Returns all compose files found during automatic discovery, including:
+    /// - File paths and project names
+    /// - Validity status (YAML parsing)
+    /// - Disabled status (x-disabled flag)
+    /// - Service lists extracted from each file
+    /// </remarks>
+    [HttpGet("files")]
+    public async Task<ActionResult<ApiResponse<List<DiscoveredComposeFileDto>>>> GetDiscoveredFiles()
+    {
+        try
+        {
+            List<DiscoveredComposeFile> files = await _composeFileCacheService.GetOrScanAsync();
+            List<DiscoveredComposeFileDto> dtos = files.Select(f => new DiscoveredComposeFileDto(
+                FilePath: f.FilePath,
+                ProjectName: f.ProjectName,
+                DirectoryPath: f.DirectoryPath,
+                LastModified: f.LastModified,
+                IsValid: f.IsValid,
+                IsDisabled: f.IsDisabled,
+                Services: f.Services
+            )).ToList();
+
+            // Filter out the application's own compose file
+            string? selfProject = await _selfFilterService.GetSelfProjectNameAsync();
+            if (selfProject != null)
+            {
+                dtos = dtos.Where(d => !selfProject.Equals(d.ProjectName, StringComparison.OrdinalIgnoreCase)).ToList();
+            }
+
+            return Ok(ApiResponse.Ok(dtos));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting discovered compose files");
+            return StatusCode(500, ApiResponse.Fail<List<DiscoveredComposeFileDto>>("Error retrieving compose files", "SERVER_ERROR"));
+        }
+    }
+
+    /// <summary>
+    /// Returns detected conflicts between compose files with the same project name
+    /// </summary>
+    /// <remarks>
+    /// Conflicts occur when multiple compose files have the same project name.
+    /// To resolve, add 'x-disabled: true' to unwanted files.
+    /// </remarks>
+    [HttpGet("conflicts")]
+    public ActionResult<ApiResponse<ConflictsResponse>> GetConflicts()
+    {
+        try
+        {
+            List<ConflictErrorDto> conflicts = _conflictService.GetConflictErrors();
+            ConflictsResponse response = new ConflictsResponse(conflicts, conflicts.Any());
+            return Ok(ApiResponse.Ok(response));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting compose conflicts");
+            return StatusCode(500, ApiResponse.Fail<ConflictsResponse>("Error retrieving conflicts", "SERVER_ERROR"));
+        }
+    }
+
+    /// <summary>
+    /// Gets health status of compose discovery system and Docker daemon
+    /// </summary>
+    /// <returns>Health status information including compose discovery and Docker daemon status</returns>
+    /// <remarks>
+    /// This diagnostic endpoint provides information about:
+    /// - Compose files directory accessibility
+    /// - Docker daemon connection status
+    /// - Overall system health (healthy, degraded, or critical)
+    ///
+    /// The endpoint returns different statuses:
+    /// - "healthy": All systems operational
+    /// - "degraded": Compose discovery unavailable but Docker accessible (can still manage existing projects)
+    /// - "critical": Docker daemon inaccessible (system non-functional)
+    ///
+    /// No authentication required - this is a diagnostic endpoint.
+    /// </remarks>
+    [HttpGet("health")]
+    [AllowAnonymous]
+    public async Task<ActionResult<ApiResponse<ComposeHealthDto>>> GetHealth()
+    {
+        // Check compose discovery directory
+        string rootPath = _composeOptions.Value.RootPath;
+        bool dirExists = Directory.Exists(rootPath);
+        bool dirAccessible = false;
+
+        if (dirExists)
+        {
+            try
+            {
+                Directory.GetFiles(rootPath);
+                dirAccessible = true;
+            }
+            catch
+            {
+                // Directory exists but not accessible
+            }
+        }
+
+        // Check Docker daemon
+        bool dockerConnected = false;
+        string? dockerVersion = null;
+        string? dockerApiVersion = null;
+        string? dockerError = null;
+
+        try
+        {
+            (dockerVersion, dockerApiVersion) = await _dockerService.GetVersionAsync();
+            dockerConnected = true;
+        }
+        catch (Exception ex)
+        {
+            dockerError = ex.Message;
+        }
+
+        // Determine overall status
+        string overallStatus;
+        if (!dockerConnected)
+            overallStatus = "critical"; // Docker inaccessible
+        else if (!dirAccessible)
+            overallStatus = "degraded"; // Directory inaccessible
+        else
+            overallStatus = "healthy";
+
+        ComposeHealthDto healthDto = new ComposeHealthDto(
+            Status: overallStatus,
+            ComposeDiscovery: new ComposeHealthStatusDto(
+                Status: dirAccessible ? "healthy" : "degraded",
+                RootPath: rootPath,
+                Exists: dirExists,
+                Accessible: dirAccessible,
+                DegradedMode: !dirAccessible,
+                Message: dirAccessible ? null : "Compose files directory is not accessible",
+                Impact: dirAccessible ? null : "Only existing Docker projects can be managed. Compose file discovery is disabled."
+            ),
+            DockerDaemon: new DockerDaemonStatusDto(
+                Status: dockerConnected ? "healthy" : "unhealthy",
+                Connected: dockerConnected,
+                Version: dockerVersion,
+                ApiVersion: dockerApiVersion,
+                Error: dockerError
+            )
+        );
+
+        return Ok(ApiResponse.Ok(healthDto));
+    }
+
+    /// <summary>
+    /// Manually refreshes the compose file discovery cache
+    /// </summary>
+    /// <remarks>
+    /// Invalidates the cache and performs a fresh filesystem scan.
+    /// Use this after adding, modifying, or removing compose files.
+    /// </remarks>
+    /// <returns>Scan results with file count and timestamp</returns>
+    [HttpPost("refresh")]
+    [Authorize(Roles = "admin")]
+    public async Task<ActionResult<ApiResponse<object>>> RefreshComposeFiles()
+    {
+        int? userId = GetCurrentUserId();
+        if (!userId.HasValue)
+        {
+            return Unauthorized(ApiResponse.Fail<object>("User not authenticated"));
+        }
+
+        _logger.LogInformation("Admin user {UserId} triggered manual cache refresh", userId.Value);
+
+        // Invalidate cache
+        _composeFileCacheService.Invalidate();
+
+        // Trigger fresh scan
+        List<DiscoveredComposeFile> files = await _composeFileCacheService.GetOrScanAsync(bypassCache: true);
+
+        await _auditService.LogActionAsync(
+            userId.Value,
+            "compose.cache_refresh",
+            GetUserIpAddress(),
+            $"Manual cache refresh triggered, found {files.Count} files",
+            resourceType: "System",
+            resourceId: "ComposeDiscovery"
+        );
+
+        return Ok(ApiResponse.Ok(new
+        {
+            success = true,
+            message = $"Cache refreshed. Found {files.Count} compose files.",
+            filesDiscovered = files.Count,
+            timestamp = DateTime.UtcNow
+        }));
+    }
+}


### PR DESCRIPTION
Second seam of the ComposeController split. Moves the compose discovery / health endpoints out.

## What moved → `ComposeFilesController`
- `GET files` — list discovered compose files (filters the app's own project)
- `GET conflicts` — duplicate project-name conflicts
- `GET health` — `[AllowAnonymous]` diagnostic (compose dir + Docker daemon)
- `POST refresh` — admin, invalidate cache + rescan

Explicit `[Route("api/compose")]` → public routes byte-for-byte unchanged (frontend untouched).

## Decoupling
Removes three now-unused deps from ComposeController: `IConflictResolutionService`, `IOptions<ComposeDiscoveryOptions>`, `DockerService`. `IComposeFileCacheService` stays (still used by the projects refresh path).

ComposeController: **1631 → 1418** (was 1902 before the split started).

## Tests (per the standing "tests with each refactor" rule)
`ComposeFilesControllerTests` — 5 tests: file→DTO mapping, self-project filtering, conflicts response, refresh 401-unauthenticated, refresh invalidate+rescan+audit. The `health` endpoint depends on the concrete `DockerService` (live daemon), so it's covered by the app-level `/health` smoke instead of a unit test.

## Verification
- `dotnet build -c Release` → 0 warnings, 0 errors.
- `dotnet test` → 320 passed (3 integration skipped).
- App boots, no ambiguous-route error: `files`/`conflicts`/`refresh` → 401 (auth), `health` → 200 (anonymous, real Docker), `projects` → 401.

## Remaining seams
- `ComposeUpdateService` split (orchestrator vs checker)
- domain exceptions + global exception middleware
- (ComposeController is now 1418 lines of projects-lifecycle; could split further if desired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)