### PR TITLE
refactor: extract ComposeUpdateChecker from ComposeUpdateService (PR6)

### DIFF
--- a/lighthouse-back/lighthouse-back.Tests/Services/ComposeUpdateCheckerTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/ComposeUpdateCheckerTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using Lighthouse.Configuration;
+using Lighthouse.DTOs;
+using Lighthouse.Models;
+using Lighthouse.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Lighthouse.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="ComposeUpdateChecker"/> (extracted from ComposeUpdateService in PR6). Covers
+/// the cache delegation and compose-file resolution. The digest-checking path pulls in the concrete
+/// DockerService (live daemon), so it isn't unit-tested here.
+/// </summary>
+public class ComposeUpdateCheckerTests
+{
+    private readonly Mock<IImageDigestService> _imageDigest = new();
+    private readonly Mock<IImageUpdateCacheService> _cache = new();
+    private readonly Mock<IComposeFileCacheService> _fileCache = new();
+    private readonly Mock<IProjectMatchingService> _projectMatching = new();
+
+    private ComposeUpdateChecker CreateChecker() => new(
+        _imageDigest.Object,
+        _cache.Object,
+        _fileCache.Object,
+        _projectMatching.Object,
+        dockerService: null!,   // only used by the digest-check path, not exercised here
+        sseManager: null!,      // only used by CheckAllProjectsUpdatesAsync's broadcast
+        Options.Create(new UpdateCheckOptions()),
+        new NullLogger<ComposeUpdateChecker>());
+
+    private static DiscoveredComposeFile DiscoveredFile(string project, string path) => new()
+    {
+        FilePath = path,
+        ProjectName = project,
+        DirectoryPath = "/c",
+        IsValid = true
+    };
+
+    [Fact]
+    public void GetGlobalUpdateStatus_DelegatesToCache()
+    {
+        var summaries = new List<ProjectUpdateSummary> { new("proj", 1, DateTime.UtcNow) };
+        _cache.Setup(c => c.GetAllCachedSummaries()).Returns(summaries);
+
+        CreateChecker().GetGlobalUpdateStatus().Should().BeSameAs(summaries);
+    }
+
+    [Fact]
+    public void ClearCache_InvalidatesAll()
+    {
+        CreateChecker().ClearCache();
+        _cache.Verify(c => c.InvalidateAll(), Times.Once);
+    }
+
+    [Fact]
+    public async Task FindComposeFilePathAsync_DirectNameMatch_ReturnsPath()
+    {
+        _fileCache.Setup(f => f.GetOrScanAsync(false))
+            .ReturnsAsync(new List<DiscoveredComposeFile> { DiscoveredFile("proj", "/c/proj/docker-compose.yml") });
+
+        string? path = await CreateChecker().FindComposeFilePathAsync("proj");
+
+        path.Should().Be("/c/proj/docker-compose.yml");
+        _projectMatching.Verify(p => p.GetUnifiedProjectListAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task FindComposeFilePathAsync_FallsBackToProjectMatching()
+    {
+        _fileCache.Setup(f => f.GetOrScanAsync(false)).ReturnsAsync(new List<DiscoveredComposeFile>());
+        _projectMatching.Setup(p => p.GetUnifiedProjectListAsync(It.IsAny<int>()))
+            .ReturnsAsync(new List<ComposeProjectDto>
+            {
+                new("proj", "/q", "running", new List<ComposeServiceDto>(), new List<string>(), null,
+                    ComposeFilePath: "/q/docker-compose.yml", HasComposeFile: true)
+            });
+
+        string? path = await CreateChecker().FindComposeFilePathAsync("proj");
+
+        path.Should().Be("/q/docker-compose.yml");
+    }
+
+    [Fact]
+    public async Task FindComposeFilePathAsync_NotFound_ReturnsNull()
+    {
+        _fileCache.Setup(f => f.GetOrScanAsync(false)).ReturnsAsync(new List<DiscoveredComposeFile>());
+        _projectMatching.Setup(p => p.GetUnifiedProjectListAsync(It.IsAny<int>()))
+            .ReturnsAsync(new List<ComposeProjectDto>());
+
+        string? path = await CreateChecker().FindComposeFilePathAsync("missing");
+
+        path.Should().BeNull();
+    }
+}

--- a/lighthouse-back/lighthouse-back.Tests/Services/ComposeUpdateServiceTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/ComposeUpdateServiceTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using Lighthouse.Configuration;
+using Lighthouse.DTOs;
+using Lighthouse.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Lighthouse.Tests.Services;
+
+/// <summary>
+/// Tests that <see cref="ComposeUpdateService"/> forwards the check/status concern to the injected
+/// <see cref="IComposeUpdateChecker"/> after the PR6 split. The update-orchestration methods drive
+/// real docker side-effects and are not unit-tested here.
+/// </summary>
+public class ComposeUpdateServiceTests
+{
+    private readonly Mock<IComposeUpdateChecker> _checker = new();
+
+    private ComposeUpdateService CreateService() => new(
+        _checker.Object,
+        cacheService: null!,
+        auditService: null!,
+        dockerExecutor: null!,
+        envFileResolver: null!,
+        progressParser: null!,
+        operationServiceDb: null!,
+        rateLimitGate: null!,
+        Options.Create(new UpdateCheckOptions()),
+        new NullLogger<ComposeUpdateService>());
+
+    [Fact]
+    public async Task CheckProjectUpdatesAsync_DelegatesToChecker()
+    {
+        var response = new ProjectUpdateCheckResponse("proj", new List<ImageUpdateStatus>(), false, DateTime.UtcNow);
+        _checker.Setup(c => c.CheckProjectUpdatesAsync("proj", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        (await CreateService().CheckProjectUpdatesAsync("proj", true)).Should().BeSameAs(response);
+    }
+
+    [Fact]
+    public void GetGlobalUpdateStatus_DelegatesToChecker()
+    {
+        var summaries = new List<ProjectUpdateSummary> { new("proj", 1, DateTime.UtcNow) };
+        _checker.Setup(c => c.GetGlobalUpdateStatus()).Returns(summaries);
+
+        CreateService().GetGlobalUpdateStatus().Should().BeSameAs(summaries);
+    }
+
+    [Fact]
+    public void ClearCache_DelegatesToChecker()
+    {
+        CreateService().ClearCache();
+        _checker.Verify(c => c.ClearCache(), Times.Once);
+    }
+
+    [Fact]
+    public async Task CheckAllProjectsUpdatesAsync_DelegatesToChecker()
+    {
+        var response = new CheckAllUpdatesResponse(new List<ProjectUpdateSummary>(), 2, 1, 1, DateTime.UtcNow);
+        _checker.Setup(c => c.CheckAllProjectsUpdatesAsync(7, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        (await CreateService().CheckAllProjectsUpdatesAsync(7)).Should().BeSameAs(response);
+    }
+}

--- a/lighthouse-back/lighthouse-back/src/Extensions/ServiceCollectionExtensions.cs
+++ b/lighthouse-back/lighthouse-back/src/Extensions/ServiceCollectionExtensions.cs
@@ -104,6 +104,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IImageUpdateCacheService, ImageUpdateCacheService>();
         services.AddSingleton<IContainerUpdateCacheService, ContainerUpdateCacheService>();
         services.AddSingleton<DockerPullProgressParser>();
+        services.AddScoped<IComposeUpdateChecker, ComposeUpdateChecker>();
         services.AddScoped<IComposeUpdateService, ComposeUpdateService>();
         services.AddScoped<IContainerUpdateService, ContainerUpdateService>();
         return services;

--- a/lighthouse-back/lighthouse-back/src/Services/ComposeUpdateChecker.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/ComposeUpdateChecker.cs
@@ -1,0 +1,495 @@
+using Lighthouse.Configuration;
+using Lighthouse.DTOs;
+using Microsoft.Extensions.Options;
+using YamlDotNet.Serialization;
+
+namespace Lighthouse.Services;
+
+/// <summary>
+/// Read-only half of the compose update feature: resolves a project's compose file, parses its
+/// service images and queries the registries (via <see cref="IImageDigestService"/>) for available
+/// updates, caching the results. Split out of <see cref="ComposeUpdateService"/> so the
+/// check/lookup concern is isolated from the update orchestration.
+/// </summary>
+public interface IComposeUpdateChecker
+{
+    /// <summary>Checks for available updates for a project's images (cached, with container states).</summary>
+    Task<ProjectUpdateCheckResponse> CheckProjectUpdatesAsync(
+        string projectName,
+        bool forceRefresh = false,
+        CancellationToken ct = default);
+
+    /// <summary>Checks for updates across all projects that have compose files.</summary>
+    Task<CheckAllUpdatesResponse> CheckAllProjectsUpdatesAsync(
+        int userId,
+        bool forceRefresh = false,
+        CancellationToken ct = default);
+
+    /// <summary>Gets the global update status for all cached projects.</summary>
+    List<ProjectUpdateSummary> GetGlobalUpdateStatus();
+
+    /// <summary>Clears the update check cache.</summary>
+    void ClearCache();
+
+    /// <summary>Resolves the compose file path for a project (used by the update orchestration too).</summary>
+    Task<string?> FindComposeFilePathAsync(string projectName);
+}
+
+public class ComposeUpdateChecker : IComposeUpdateChecker
+{
+    private readonly IImageDigestService _imageDigestService;
+    private readonly IImageUpdateCacheService _cacheService;
+    private readonly IComposeFileCacheService _fileCacheService;
+    private readonly IProjectMatchingService _projectMatchingService;
+    private readonly DockerService _dockerService;
+    private readonly SseConnectionManagerService _sseManager;
+    private readonly UpdateCheckOptions _options;
+    private readonly ILogger<ComposeUpdateChecker> _logger;
+
+    private readonly SemaphoreSlim _checkLock = new(1, 1);
+
+    public ComposeUpdateChecker(
+        IImageDigestService imageDigestService,
+        IImageUpdateCacheService cacheService,
+        IComposeFileCacheService fileCacheService,
+        IProjectMatchingService projectMatchingService,
+        DockerService dockerService,
+        SseConnectionManagerService sseManager,
+        IOptions<UpdateCheckOptions> options,
+        ILogger<ComposeUpdateChecker> logger)
+    {
+        _imageDigestService = imageDigestService;
+        _cacheService = cacheService;
+        _fileCacheService = fileCacheService;
+        _projectMatchingService = projectMatchingService;
+        _dockerService = dockerService;
+        _sseManager = sseManager;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<ProjectUpdateCheckResponse> CheckProjectUpdatesAsync(
+        string projectName,
+        bool forceRefresh = false,
+        CancellationToken ct = default)
+    {
+        if (forceRefresh)
+            _cacheService.InvalidateProject(projectName);
+
+        ProjectUpdateCheckResponse result = await CheckProjectUpdatesInternalAsync(projectName, null, ct);
+
+        // Enrich images with container state from Docker
+        return await EnrichWithContainerStatesAsync(projectName, result);
+    }
+
+    private async Task<ProjectUpdateCheckResponse> CheckProjectUpdatesInternalAsync(
+        string projectName,
+        string? knownComposeFilePath,
+        CancellationToken ct = default)
+    {
+        // Check cache first
+        ProjectUpdateCheckResponse? cached = _cacheService.GetCachedCheck(projectName);
+        if (cached != null)
+        {
+            return cached;
+        }
+
+        await _checkLock.WaitAsync(ct);
+        try
+        {
+            // Double-check after acquiring lock
+            cached = _cacheService.GetCachedCheck(projectName);
+            if (cached != null)
+            {
+                return cached;
+            }
+
+            _logger.LogDebug("Checking updates for project {ProjectName}", projectName);
+
+            // Use pre-resolved path if available, otherwise look it up
+            string? composeFilePath = knownComposeFilePath ?? await FindComposeFilePathAsync(projectName);
+
+            if (composeFilePath == null)
+            {
+                _logger.LogWarning("No compose file found for project {ProjectName}", projectName);
+                return new ProjectUpdateCheckResponse(
+                    ProjectName: projectName,
+                    Images: new List<ImageUpdateStatus>(),
+                    HasUpdates: false,
+                    LastChecked: DateTime.UtcNow
+                );
+            }
+
+            _logger.LogDebug("Found compose file for project {ProjectName}: {FilePath}", projectName, composeFilePath);
+
+            // Parse compose file to get services and images
+            Dictionary<string, ServiceImageInfo> serviceImages = await ParseServiceImagesAsync(composeFilePath, ct);
+
+            // Check each image for updates (with concurrency limit)
+            SemaphoreSlim semaphore = new SemaphoreSlim(_options.MaxConcurrentChecks);
+            List<Task<ImageUpdateStatus>> tasks = new List<Task<ImageUpdateStatus>>();
+
+            foreach ((string? serviceName, ServiceImageInfo? imageInfo) in serviceImages)
+            {
+                if (string.IsNullOrEmpty(imageInfo.Image))
+                {
+                    // Service uses build, not image
+                    continue;
+                }
+
+                // Check if image is excluded
+                if (IsImageExcluded(imageInfo.Image))
+                {
+                    _logger.LogDebug("Image {Image} is excluded from update checks", imageInfo.Image);
+                    continue;
+                }
+
+                tasks.Add(CheckImageWithSemaphoreAsync(
+                    semaphore,
+                    imageInfo.Image,
+                    serviceName,
+                    imageInfo.UpdatePolicy,
+                    ct));
+            }
+
+            ImageUpdateStatus[] results = await Task.WhenAll(tasks);
+
+            ProjectUpdateCheckResponse response = new ProjectUpdateCheckResponse(
+                ProjectName: projectName,
+                Images: results.ToList(),
+                HasUpdates: results.Any(r => r.UpdateAvailable && r.UpdatePolicy != "disabled"),
+                LastChecked: DateTime.UtcNow
+            );
+
+            // Cache the result
+            _cacheService.SetCachedCheck(projectName, response);
+
+            _logger.LogDebug(
+                "Update check complete for {ProjectName}: {UpdateCount} updates available out of {TotalCount} images",
+                projectName,
+                results.Count(r => r.UpdateAvailable),
+                results.Length);
+
+            return response;
+        }
+        finally
+        {
+            _checkLock.Release();
+        }
+    }
+
+    private async Task<ImageUpdateStatus> CheckImageWithSemaphoreAsync(
+        SemaphoreSlim semaphore,
+        string image,
+        string serviceName,
+        string? updatePolicy,
+        CancellationToken ct)
+    {
+        await semaphore.WaitAsync(ct);
+        try
+        {
+            ImageUpdateStatus status = await _imageDigestService.CheckImageUpdateAsync(image, serviceName, ct);
+
+            // Apply update policy from compose file
+            return status with { UpdatePolicy = updatePolicy };
+        }
+        finally
+        {
+            semaphore.Release();
+        }
+    }
+
+    private async Task<ProjectUpdateCheckResponse> EnrichWithContainerStatesAsync(
+        string projectName,
+        ProjectUpdateCheckResponse response)
+    {
+        try
+        {
+            List<ContainerDto> allContainers = await _dockerService.ListContainersAsync();
+            Dictionary<string, string> serviceStateMap = allContainers
+                .Where(c => c.Labels != null
+                    && string.Equals(
+                        c.Labels.GetValueOrDefault("com.docker.compose.project"),
+                        projectName,
+                        StringComparison.OrdinalIgnoreCase))
+                .GroupBy(c => c.Labels!.GetValueOrDefault("com.docker.compose.service") ?? "")
+                .Where(g => !string.IsNullOrEmpty(g.Key))
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.First().State,
+                    StringComparer.OrdinalIgnoreCase);
+
+            List<ImageUpdateStatus> enrichedImages = response.Images
+                .Select(img => img with
+                {
+                    ContainerState = serviceStateMap.GetValueOrDefault(img.ServiceName)
+                })
+                .ToList();
+
+            return response with { Images = enrichedImages };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to enrich container states for project {ProjectName}", projectName);
+            return response;
+        }
+    }
+
+    public List<ProjectUpdateSummary> GetGlobalUpdateStatus()
+    {
+        return _cacheService.GetAllCachedSummaries();
+    }
+
+    public void ClearCache()
+    {
+        _cacheService.InvalidateAll();
+        _logger.LogDebug("Update check cache cleared");
+    }
+
+    public async Task<CheckAllUpdatesResponse> CheckAllProjectsUpdatesAsync(
+        int userId,
+        bool forceRefresh = false,
+        CancellationToken ct = default)
+    {
+        _logger.LogDebug("Checking updates for all projects (user: {UserId}, forceRefresh: {ForceRefresh})", userId, forceRefresh);
+
+        if (forceRefresh)
+            _cacheService.InvalidateAll();
+
+        // Get all projects with compose files
+        List<ComposeProjectDto> allProjects = await _projectMatchingService.GetUnifiedProjectListAsync(userId);
+        List<ComposeProjectDto> projectsWithFiles = allProjects
+            .Where(p => p.HasComposeFile && !string.IsNullOrEmpty(p.ComposeFilePath))
+            .ToList();
+
+        _logger.LogDebug("Found {Count} projects with compose files to check", projectsWithFiles.Count);
+
+        List<ProjectUpdateSummary> summaries = new List<ProjectUpdateSummary>();
+        int totalServicesWithUpdates = 0;
+
+        // Check each project sequentially to avoid rate limiting
+        foreach (ComposeProjectDto? project in projectsWithFiles)
+        {
+            if (ct.IsCancellationRequested)
+                break;
+
+            try
+            {
+                ProjectUpdateCheckResponse checkResult = await CheckProjectUpdatesInternalAsync(project.Name, project.ComposeFilePath, ct);
+
+                int servicesWithUpdates = checkResult.Images
+                    .Count(i => i.UpdateAvailable && i.UpdatePolicy != "disabled");
+
+                bool hasRunningServices = project.Services.Any(s =>
+                    string.Equals(s.State, "running", StringComparison.OrdinalIgnoreCase));
+
+                summaries.Add(new ProjectUpdateSummary(
+                    ProjectName: project.Name,
+                    ServicesWithUpdates: servicesWithUpdates,
+                    LastChecked: checkResult.LastChecked,
+                    HasRunningServices: hasRunningServices
+                ));
+
+                totalServicesWithUpdates += servicesWithUpdates;
+
+                _logger.LogDebug(
+                    "Project {ProjectName}: {UpdateCount} services with updates",
+                    project.Name,
+                    servicesWithUpdates);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error checking updates for project {ProjectName}", project.Name);
+                // Add project with 0 updates on error so it still appears in the list
+                summaries.Add(new ProjectUpdateSummary(
+                    ProjectName: project.Name,
+                    ServicesWithUpdates: 0,
+                    LastChecked: null
+                ));
+            }
+        }
+
+        int projectsWithUpdates = summaries.Count(s => s.ServicesWithUpdates > 0);
+
+        _logger.LogDebug(
+            "Bulk update check complete: {ProjectsChecked} projects checked, {ProjectsWithUpdates} with updates, {TotalServices} total services",
+            summaries.Count,
+            projectsWithUpdates,
+            totalServicesWithUpdates);
+
+        CheckAllUpdatesResponse response = new CheckAllUpdatesResponse(
+            Projects: summaries,
+            ProjectsChecked: summaries.Count,
+            ProjectsWithUpdates: projectsWithUpdates,
+            TotalServicesWithUpdates: totalServicesWithUpdates,
+            CheckedAt: DateTime.UtcNow
+        );
+
+        // Broadcast SSE event for manual check
+        try
+        {
+            ProjectUpdatesCheckedEvent sseEvent = new(
+                Projects: response.Projects,
+                ProjectsChecked: response.ProjectsChecked,
+                ProjectsWithUpdates: response.ProjectsWithUpdates,
+                TotalServicesWithUpdates: response.TotalServicesWithUpdates,
+                CheckedAt: response.CheckedAt,
+                Trigger: "manual"
+            );
+            await _sseManager.BroadcastAsync("ProjectUpdatesChecked", sseEvent);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to broadcast ProjectUpdatesChecked SSE event");
+        }
+
+        return response;
+    }
+
+    private async Task<Dictionary<string, ServiceImageInfo>> ParseServiceImagesAsync(
+        string composeFilePath,
+        CancellationToken ct)
+    {
+        Dictionary<string, ServiceImageInfo> result = new Dictionary<string, ServiceImageInfo>();
+
+        try
+        {
+            string content = await File.ReadAllTextAsync(composeFilePath, ct);
+
+            IDeserializer deserializer = new DeserializerBuilder()
+                .IgnoreUnmatchedProperties()
+                .Build();
+
+            Dictionary<string, object> composeData = deserializer.Deserialize<Dictionary<string, object>>(content);
+
+            if (composeData == null ||
+                !composeData.TryGetValue("services", out object? servicesObj) ||
+                servicesObj is not Dictionary<object, object> services)
+            {
+                return result;
+            }
+
+            foreach ((object? serviceKey, object? serviceValue) in services)
+            {
+                string serviceName = serviceKey.ToString() ?? "";
+                if (serviceValue is not Dictionary<object, object> serviceData)
+                    continue;
+
+                string? image = null;
+                string? updatePolicy = null;
+
+                if (serviceData.TryGetValue("image", out object? imageObj))
+                {
+                    image = imageObj?.ToString();
+                }
+
+                // Check for x-update-policy extension
+                if (serviceData.TryGetValue("x-update-policy", out object? policyObj))
+                {
+                    updatePolicy = policyObj?.ToString()?.ToLowerInvariant();
+                }
+
+                // Also check at root level for project-wide policy
+                if (updatePolicy == null && composeData.TryGetValue("x-update-policy", out object? rootPolicyObj))
+                {
+                    updatePolicy = rootPolicyObj?.ToString()?.ToLowerInvariant();
+                }
+
+                result[serviceName] = new ServiceImageInfo(image, updatePolicy);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error parsing compose file {Path}", composeFilePath);
+        }
+
+        return result;
+    }
+
+    private bool IsImageExcluded(string image)
+    {
+        foreach (string pattern in _options.ExcludedImages)
+        {
+            if (MatchesPattern(image, pattern))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool MatchesPattern(string value, string pattern)
+    {
+        // Simple wildcard matching
+        if (pattern.Contains('*'))
+        {
+            string regexPattern = "^" + System.Text.RegularExpressions.Regex.Escape(pattern)
+                .Replace("\\*", ".*") + "$";
+            return System.Text.RegularExpressions.Regex.IsMatch(
+                value,
+                regexPattern,
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        }
+
+        return string.Equals(value, pattern, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Finds the compose file path for a project using the ProjectMatchingService.
+    /// This reuses the same sophisticated matching logic used for the projects list,
+    /// handling cases where Docker's project name differs from the compose file's project name.
+    /// </summary>
+    /// <param name="projectName">The project name as reported by Docker</param>
+    /// <returns>The compose file path if found, null otherwise</returns>
+    public async Task<string?> FindComposeFilePathAsync(string projectName)
+    {
+        try
+        {
+            // Fast path: most projects map to a discovered file whose ProjectName matches directly
+            // (this is the dominant "Match found by project name" case). Resolving it from the cached
+            // discovery avoids rebuilding the whole unified project list (docker compose ls + matching
+            // + per-project cache scan) just to find one project's compose file.
+            List<Models.DiscoveredComposeFile> discoveredFiles = await _fileCacheService.GetOrScanAsync();
+            Models.DiscoveredComposeFile? directMatch = discoveredFiles.FirstOrDefault(f =>
+                f.ProjectName.Equals(projectName, StringComparison.OrdinalIgnoreCase));
+            if (directMatch != null && !string.IsNullOrEmpty(directMatch.FilePath))
+            {
+                _logger.LogDebug(
+                    "Found compose file by name for project {ProjectName}: {FilePath}",
+                    projectName, directMatch.FilePath);
+                return directMatch.FilePath;
+            }
+
+            // Fallback: the full unified list handles edge cases the direct lookup misses
+            // (path-based / filename+directory matching, Docker project name differing from the file name).
+            // We use userId 1 (default admin) since this is only called from admin endpoints
+            const int systemAdminUserId = 1;
+            List<ComposeProjectDto> projects = await _projectMatchingService.GetUnifiedProjectListAsync(systemAdminUserId);
+
+            // Find the project by name (case-insensitive)
+            ComposeProjectDto? matchedProject = projects.FirstOrDefault(p =>
+                p.Name.Equals(projectName, StringComparison.OrdinalIgnoreCase));
+
+            if (matchedProject != null && matchedProject.HasComposeFile)
+            {
+                _logger.LogDebug(
+                    "Found compose file via ProjectMatchingService for project {ProjectName}: {FilePath}",
+                    projectName,
+                    matchedProject.ComposeFilePath);
+                return matchedProject.ComposeFilePath;
+            }
+
+            _logger.LogDebug(
+                "No compose file found via ProjectMatchingService for project {ProjectName}",
+                projectName);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error finding compose file path for project {ProjectName}", projectName);
+            return null;
+        }
+    }
+
+    private record ServiceImageInfo(string? Image, string? UpdatePolicy);
+}

--- a/lighthouse-back/lighthouse-back/src/Services/ComposeUpdateService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/ComposeUpdateService.cs
@@ -62,227 +62,60 @@ public interface IComposeUpdateService
 
 public class ComposeUpdateService : IComposeUpdateService
 {
-    private readonly IComposeDiscoveryService _discoveryService;
-    private readonly IComposeOperationService _composeOperationService;
-    private readonly IImageDigestService _imageDigestService;
+    private readonly IComposeUpdateChecker _checker;
     private readonly IImageUpdateCacheService _cacheService;
-    private readonly IComposeFileCacheService _fileCacheService;
-    private readonly IProjectMatchingService _projectMatchingService;
     private readonly IAuditService _auditService;
-    private readonly DockerService _dockerService;
     private readonly DockerCommandExecutorService _dockerExecutor;
     private readonly IComposeEnvFileResolver _envFileResolver;
     private readonly DockerPullProgressParser _progressParser;
     private readonly OperationService _operationService;
-    private readonly SseConnectionManagerService _sseManager;
     private readonly IRegistryRateLimitGate _rateLimitGate;
     private readonly ILogger<ComposeUpdateService> _logger;
     private readonly UpdateCheckOptions _options;
 
-    private readonly SemaphoreSlim _checkLock = new(1, 1);
-
     public ComposeUpdateService(
-        IComposeDiscoveryService discoveryService,
-        IComposeOperationService operationService,
-        IImageDigestService imageDigestService,
+        IComposeUpdateChecker checker,
         IImageUpdateCacheService cacheService,
-        IComposeFileCacheService fileCacheService,
-        IProjectMatchingService projectMatchingService,
         IAuditService auditService,
-        DockerService dockerService,
         DockerCommandExecutorService dockerExecutor,
         IComposeEnvFileResolver envFileResolver,
         DockerPullProgressParser progressParser,
         OperationService operationServiceDb,
-        SseConnectionManagerService sseManager,
         IRegistryRateLimitGate rateLimitGate,
         IOptions<UpdateCheckOptions> options,
         ILogger<ComposeUpdateService> logger)
     {
-        _discoveryService = discoveryService;
-        _composeOperationService = operationService;
-        _imageDigestService = imageDigestService;
+        _checker = checker;
         _cacheService = cacheService;
-        _fileCacheService = fileCacheService;
-        _projectMatchingService = projectMatchingService;
         _auditService = auditService;
-        _dockerService = dockerService;
         _dockerExecutor = dockerExecutor;
         _envFileResolver = envFileResolver;
         _progressParser = progressParser;
         _operationService = operationServiceDb;
-        _sseManager = sseManager;
         _rateLimitGate = rateLimitGate;
         _options = options.Value;
         _logger = logger;
     }
 
-    public async Task<ProjectUpdateCheckResponse> CheckProjectUpdatesAsync(
+    // Update check / status concern is delegated to the ComposeUpdateChecker collaborator.
+
+    public Task<ProjectUpdateCheckResponse> CheckProjectUpdatesAsync(
         string projectName,
         bool forceRefresh = false,
         CancellationToken ct = default)
-    {
-        if (forceRefresh)
-            _cacheService.InvalidateProject(projectName);
+        => _checker.CheckProjectUpdatesAsync(projectName, forceRefresh, ct);
 
-        ProjectUpdateCheckResponse result = await CheckProjectUpdatesInternalAsync(projectName, null, ct);
+    public List<ProjectUpdateSummary> GetGlobalUpdateStatus()
+        => _checker.GetGlobalUpdateStatus();
 
-        // Enrich images with container state from Docker
-        return await EnrichWithContainerStatesAsync(projectName, result);
-    }
+    public void ClearCache()
+        => _checker.ClearCache();
 
-    private async Task<ProjectUpdateCheckResponse> CheckProjectUpdatesInternalAsync(
-        string projectName,
-        string? knownComposeFilePath,
+    public Task<CheckAllUpdatesResponse> CheckAllProjectsUpdatesAsync(
+        int userId,
+        bool forceRefresh = false,
         CancellationToken ct = default)
-    {
-        // Check cache first
-        ProjectUpdateCheckResponse? cached = _cacheService.GetCachedCheck(projectName);
-        if (cached != null)
-        {
-            return cached;
-        }
-
-        await _checkLock.WaitAsync(ct);
-        try
-        {
-            // Double-check after acquiring lock
-            cached = _cacheService.GetCachedCheck(projectName);
-            if (cached != null)
-            {
-                return cached;
-            }
-
-            _logger.LogDebug("Checking updates for project {ProjectName}", projectName);
-
-            // Use pre-resolved path if available, otherwise look it up
-            string? composeFilePath = knownComposeFilePath ?? await FindComposeFilePathAsync(projectName);
-
-            if (composeFilePath == null)
-            {
-                _logger.LogWarning("No compose file found for project {ProjectName}", projectName);
-                return new ProjectUpdateCheckResponse(
-                    ProjectName: projectName,
-                    Images: new List<ImageUpdateStatus>(),
-                    HasUpdates: false,
-                    LastChecked: DateTime.UtcNow
-                );
-            }
-
-            _logger.LogDebug("Found compose file for project {ProjectName}: {FilePath}", projectName, composeFilePath);
-
-            // Parse compose file to get services and images
-            Dictionary<string, ServiceImageInfo> serviceImages = await ParseServiceImagesAsync(composeFilePath, ct);
-
-            // Check each image for updates (with concurrency limit)
-            SemaphoreSlim semaphore = new SemaphoreSlim(_options.MaxConcurrentChecks);
-            List<Task<ImageUpdateStatus>> tasks = new List<Task<ImageUpdateStatus>>();
-
-            foreach ((string? serviceName, ServiceImageInfo? imageInfo) in serviceImages)
-            {
-                if (string.IsNullOrEmpty(imageInfo.Image))
-                {
-                    // Service uses build, not image
-                    continue;
-                }
-
-                // Check if image is excluded
-                if (IsImageExcluded(imageInfo.Image))
-                {
-                    _logger.LogDebug("Image {Image} is excluded from update checks", imageInfo.Image);
-                    continue;
-                }
-
-                tasks.Add(CheckImageWithSemaphoreAsync(
-                    semaphore,
-                    imageInfo.Image,
-                    serviceName,
-                    imageInfo.UpdatePolicy,
-                    ct));
-            }
-
-            ImageUpdateStatus[] results = await Task.WhenAll(tasks);
-
-            ProjectUpdateCheckResponse response = new ProjectUpdateCheckResponse(
-                ProjectName: projectName,
-                Images: results.ToList(),
-                HasUpdates: results.Any(r => r.UpdateAvailable && r.UpdatePolicy != "disabled"),
-                LastChecked: DateTime.UtcNow
-            );
-
-            // Cache the result
-            _cacheService.SetCachedCheck(projectName, response);
-
-            _logger.LogDebug(
-                "Update check complete for {ProjectName}: {UpdateCount} updates available out of {TotalCount} images",
-                projectName,
-                results.Count(r => r.UpdateAvailable),
-                results.Length);
-
-            return response;
-        }
-        finally
-        {
-            _checkLock.Release();
-        }
-    }
-
-    private async Task<ImageUpdateStatus> CheckImageWithSemaphoreAsync(
-        SemaphoreSlim semaphore,
-        string image,
-        string serviceName,
-        string? updatePolicy,
-        CancellationToken ct)
-    {
-        await semaphore.WaitAsync(ct);
-        try
-        {
-            ImageUpdateStatus status = await _imageDigestService.CheckImageUpdateAsync(image, serviceName, ct);
-
-            // Apply update policy from compose file
-            return status with { UpdatePolicy = updatePolicy };
-        }
-        finally
-        {
-            semaphore.Release();
-        }
-    }
-
-    private async Task<ProjectUpdateCheckResponse> EnrichWithContainerStatesAsync(
-        string projectName,
-        ProjectUpdateCheckResponse response)
-    {
-        try
-        {
-            List<ContainerDto> allContainers = await _dockerService.ListContainersAsync();
-            Dictionary<string, string> serviceStateMap = allContainers
-                .Where(c => c.Labels != null
-                    && string.Equals(
-                        c.Labels.GetValueOrDefault("com.docker.compose.project"),
-                        projectName,
-                        StringComparison.OrdinalIgnoreCase))
-                .GroupBy(c => c.Labels!.GetValueOrDefault("com.docker.compose.service") ?? "")
-                .Where(g => !string.IsNullOrEmpty(g.Key))
-                .ToDictionary(
-                    g => g.Key,
-                    g => g.First().State,
-                    StringComparer.OrdinalIgnoreCase);
-
-            List<ImageUpdateStatus> enrichedImages = response.Images
-                .Select(img => img with
-                {
-                    ContainerState = serviceStateMap.GetValueOrDefault(img.ServiceName)
-                })
-                .ToList();
-
-            return response with { Images = enrichedImages };
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to enrich container states for project {ProjectName}", projectName);
-            return response;
-        }
-    }
+        => _checker.CheckAllProjectsUpdatesAsync(userId, forceRefresh, ct);
 
     public async Task<UpdateTriggerResponse> UpdateProjectAsync(
         string projectName,
@@ -306,8 +139,8 @@ public class ComposeUpdateService : IComposeUpdateService
                 services != null ? string.Join(", ", services) : "all",
                 updateAll);
 
-            // Use ProjectMatchingService to find the compose file path
-            string? composeFilePath = await FindComposeFilePathAsync(projectName);
+            // Use the checker to resolve the compose file path
+            string? composeFilePath = await _checker.FindComposeFilePathAsync(projectName);
 
             if (composeFilePath == null)
             {
@@ -760,11 +593,6 @@ public class ComposeUpdateService : IComposeUpdateService
         }
     }
 
-    public List<ProjectUpdateSummary> GetGlobalUpdateStatus()
-    {
-        return _cacheService.GetAllCachedSummaries();
-    }
-
     public async Task<UpdateAllResponse> UpdateAllProjectsAsync(
         int userId,
         string ipAddress,
@@ -819,12 +647,6 @@ public class ComposeUpdateService : IComposeUpdateService
         );
     }
 
-    public void ClearCache()
-    {
-        _cacheService.InvalidateAll();
-        _logger.LogDebug("Update check cache cleared");
-    }
-
     /// <summary>
     /// Turns a raw `docker compose pull` error into an actionable message. Docker reports
     /// rate-limit and auth failures generically ("toomanyrequests", "unauthorized"); when a
@@ -855,250 +677,4 @@ public class ComposeUpdateService : IComposeUpdateService
         return $"Failed to pull images: {raw}";
     }
 
-    public async Task<CheckAllUpdatesResponse> CheckAllProjectsUpdatesAsync(
-        int userId,
-        bool forceRefresh = false,
-        CancellationToken ct = default)
-    {
-        _logger.LogDebug("Checking updates for all projects (user: {UserId}, forceRefresh: {ForceRefresh})", userId, forceRefresh);
-
-        if (forceRefresh)
-            _cacheService.InvalidateAll();
-
-        // Get all projects with compose files
-        List<ComposeProjectDto> allProjects = await _projectMatchingService.GetUnifiedProjectListAsync(userId);
-        List<ComposeProjectDto> projectsWithFiles = allProjects
-            .Where(p => p.HasComposeFile && !string.IsNullOrEmpty(p.ComposeFilePath))
-            .ToList();
-
-        _logger.LogDebug("Found {Count} projects with compose files to check", projectsWithFiles.Count);
-
-        List<ProjectUpdateSummary> summaries = new List<ProjectUpdateSummary>();
-        int totalServicesWithUpdates = 0;
-
-        // Check each project sequentially to avoid rate limiting
-        foreach (ComposeProjectDto? project in projectsWithFiles)
-        {
-            if (ct.IsCancellationRequested)
-                break;
-
-            try
-            {
-                ProjectUpdateCheckResponse checkResult = await CheckProjectUpdatesInternalAsync(project.Name, project.ComposeFilePath, ct);
-
-                int servicesWithUpdates = checkResult.Images
-                    .Count(i => i.UpdateAvailable && i.UpdatePolicy != "disabled");
-
-                bool hasRunningServices = project.Services.Any(s =>
-                    string.Equals(s.State, "running", StringComparison.OrdinalIgnoreCase));
-
-                summaries.Add(new ProjectUpdateSummary(
-                    ProjectName: project.Name,
-                    ServicesWithUpdates: servicesWithUpdates,
-                    LastChecked: checkResult.LastChecked,
-                    HasRunningServices: hasRunningServices
-                ));
-
-                totalServicesWithUpdates += servicesWithUpdates;
-
-                _logger.LogDebug(
-                    "Project {ProjectName}: {UpdateCount} services with updates",
-                    project.Name,
-                    servicesWithUpdates);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Error checking updates for project {ProjectName}", project.Name);
-                // Add project with 0 updates on error so it still appears in the list
-                summaries.Add(new ProjectUpdateSummary(
-                    ProjectName: project.Name,
-                    ServicesWithUpdates: 0,
-                    LastChecked: null
-                ));
-            }
-        }
-
-        int projectsWithUpdates = summaries.Count(s => s.ServicesWithUpdates > 0);
-
-        _logger.LogDebug(
-            "Bulk update check complete: {ProjectsChecked} projects checked, {ProjectsWithUpdates} with updates, {TotalServices} total services",
-            summaries.Count,
-            projectsWithUpdates,
-            totalServicesWithUpdates);
-
-        CheckAllUpdatesResponse response = new CheckAllUpdatesResponse(
-            Projects: summaries,
-            ProjectsChecked: summaries.Count,
-            ProjectsWithUpdates: projectsWithUpdates,
-            TotalServicesWithUpdates: totalServicesWithUpdates,
-            CheckedAt: DateTime.UtcNow
-        );
-
-        // Broadcast SSE event for manual check
-        try
-        {
-            ProjectUpdatesCheckedEvent sseEvent = new(
-                Projects: response.Projects,
-                ProjectsChecked: response.ProjectsChecked,
-                ProjectsWithUpdates: response.ProjectsWithUpdates,
-                TotalServicesWithUpdates: response.TotalServicesWithUpdates,
-                CheckedAt: response.CheckedAt,
-                Trigger: "manual"
-            );
-            await _sseManager.BroadcastAsync("ProjectUpdatesChecked", sseEvent);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to broadcast ProjectUpdatesChecked SSE event");
-        }
-
-        return response;
-    }
-
-    private async Task<Dictionary<string, ServiceImageInfo>> ParseServiceImagesAsync(
-        string composeFilePath,
-        CancellationToken ct)
-    {
-        Dictionary<string, ServiceImageInfo> result = new Dictionary<string, ServiceImageInfo>();
-
-        try
-        {
-            string content = await File.ReadAllTextAsync(composeFilePath, ct);
-
-            IDeserializer deserializer = new DeserializerBuilder()
-                .IgnoreUnmatchedProperties()
-                .Build();
-
-            Dictionary<string, object> composeData = deserializer.Deserialize<Dictionary<string, object>>(content);
-
-            if (composeData == null ||
-                !composeData.TryGetValue("services", out object? servicesObj) ||
-                servicesObj is not Dictionary<object, object> services)
-            {
-                return result;
-            }
-
-            foreach ((object? serviceKey, object? serviceValue) in services)
-            {
-                string serviceName = serviceKey.ToString() ?? "";
-                if (serviceValue is not Dictionary<object, object> serviceData)
-                    continue;
-
-                string? image = null;
-                string? updatePolicy = null;
-
-                if (serviceData.TryGetValue("image", out object? imageObj))
-                {
-                    image = imageObj?.ToString();
-                }
-
-                // Check for x-update-policy extension
-                if (serviceData.TryGetValue("x-update-policy", out object? policyObj))
-                {
-                    updatePolicy = policyObj?.ToString()?.ToLowerInvariant();
-                }
-
-                // Also check at root level for project-wide policy
-                if (updatePolicy == null && composeData.TryGetValue("x-update-policy", out object? rootPolicyObj))
-                {
-                    updatePolicy = rootPolicyObj?.ToString()?.ToLowerInvariant();
-                }
-
-                result[serviceName] = new ServiceImageInfo(image, updatePolicy);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error parsing compose file {Path}", composeFilePath);
-        }
-
-        return result;
-    }
-
-    private bool IsImageExcluded(string image)
-    {
-        foreach (string pattern in _options.ExcludedImages)
-        {
-            if (MatchesPattern(image, pattern))
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static bool MatchesPattern(string value, string pattern)
-    {
-        // Simple wildcard matching
-        if (pattern.Contains('*'))
-        {
-            string regexPattern = "^" + System.Text.RegularExpressions.Regex.Escape(pattern)
-                .Replace("\\*", ".*") + "$";
-            return System.Text.RegularExpressions.Regex.IsMatch(
-                value,
-                regexPattern,
-                System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-        }
-
-        return string.Equals(value, pattern, StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
-    /// Finds the compose file path for a project using the ProjectMatchingService.
-    /// This reuses the same sophisticated matching logic used for the projects list,
-    /// handling cases where Docker's project name differs from the compose file's project name.
-    /// </summary>
-    /// <param name="projectName">The project name as reported by Docker</param>
-    /// <returns>The compose file path if found, null otherwise</returns>
-    private async Task<string?> FindComposeFilePathAsync(string projectName)
-    {
-        try
-        {
-            // Fast path: most projects map to a discovered file whose ProjectName matches directly
-            // (this is the dominant "Match found by project name" case). Resolving it from the cached
-            // discovery avoids rebuilding the whole unified project list (docker compose ls + matching
-            // + per-project cache scan) just to find one project's compose file.
-            List<Models.DiscoveredComposeFile> discoveredFiles = await _fileCacheService.GetOrScanAsync();
-            Models.DiscoveredComposeFile? directMatch = discoveredFiles.FirstOrDefault(f =>
-                f.ProjectName.Equals(projectName, StringComparison.OrdinalIgnoreCase));
-            if (directMatch != null && !string.IsNullOrEmpty(directMatch.FilePath))
-            {
-                _logger.LogDebug(
-                    "Found compose file by name for project {ProjectName}: {FilePath}",
-                    projectName, directMatch.FilePath);
-                return directMatch.FilePath;
-            }
-
-            // Fallback: the full unified list handles edge cases the direct lookup misses
-            // (path-based / filename+directory matching, Docker project name differing from the file name).
-            // We use userId 1 (default admin) since this is only called from admin endpoints
-            const int systemAdminUserId = 1;
-            List<ComposeProjectDto> projects = await _projectMatchingService.GetUnifiedProjectListAsync(systemAdminUserId);
-
-            // Find the project by name (case-insensitive)
-            ComposeProjectDto? matchedProject = projects.FirstOrDefault(p =>
-                p.Name.Equals(projectName, StringComparison.OrdinalIgnoreCase));
-
-            if (matchedProject != null && matchedProject.HasComposeFile)
-            {
-                _logger.LogDebug(
-                    "Found compose file via ProjectMatchingService for project {ProjectName}: {FilePath}",
-                    projectName,
-                    matchedProject.ComposeFilePath);
-                return matchedProject.ComposeFilePath;
-            }
-
-            _logger.LogDebug(
-                "No compose file found via ProjectMatchingService for project {ProjectName}",
-                projectName);
-            return null;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error finding compose file path for project {ProjectName}", projectName);
-            return null;
-        }
-    }
-
-    private record ServiceImageInfo(string? Image, string? UpdatePolicy);
 }


### PR DESCRIPTION
Conservative split of the 1104-line `ComposeUpdateService` (you chose this over the full orchestrator/checker split, given it resists unit testing).

## What moved → `ComposeUpdateChecker` (`IComposeUpdateChecker`)
The read-only check / lookup concern: `CheckProjectUpdates` (+ internal), `CheckAllProjects`, `GetGlobalUpdateStatus`, `ClearCache`, `FindComposeFilePath`, and the compose-image parsing / exclusion helpers. It takes only the deps those need (image-digest, caches, project-matching, docker, sse, options).

## What stays in `ComposeUpdateService`
The update orchestration (`UpdateProject` / `UpdateAll` + SSE progress + pull-error mapping). It now **delegates** the four check/status methods to the injected checker, and calls `_checker.FindComposeFilePathAsync` / `_checker.CheckProjectUpdatesAsync` where the orchestration needs them.

## Decoupling
- `ComposeUpdateService`: **16 ctor deps → 10**. Dropped the moved deps plus two that were entirely unused (`IComposeDiscoveryService`, `IComposeOperationService`).
- `ComposeUpdateService` **1104 → 680** lines; `ComposeUpdateChecker` 495.

## Tests
- `ComposeUpdateCheckerTests` — cache delegation + compose-file resolution (direct-name match, project-matching fallback, not-found).
- `ComposeUpdateServiceTests` — verifies the four check methods forward to the checker.
- The digest-check and update-orchestration paths pull in concrete docker services (live daemon) and aren't unit-tested; orchestration is covered by the app smoke + manual update flows.

## Verification
- `dotnet build -c Release` → 0 warnings, 0 errors.
- `dotnet test` → 329 passed (3 integration skipped).
- App boots, `GET /health` → 200 (the full DI graph, including the new `IComposeUpdateChecker`, resolves).

## Remaining (separate PRs)
- domain exceptions + global exception middleware
- frontend component splits + store consolidation (PR8)
- docs consolidation + CI checkout@v5 (PR9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)