### PR TITLE
feat: domain exception hierarchy + error-code constants (PR6)

### DIFF
--- a/lighthouse-back/lighthouse-back.Tests/Middleware/ErrorHandlingMiddlewareTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Middleware/ErrorHandlingMiddlewareTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Lighthouse.Constants;
+using Lighthouse.Exceptions;
+using Lighthouse.Middleware;
+using Lighthouse.Services.Registry;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Lighthouse.Tests.Middleware;
+
+/// <summary>
+/// Tests the global <see cref="ErrorHandlingMiddleware"/> exception → HTTP response mapping, including
+/// the new domain <see cref="AppException"/> hierarchy added in PR6.
+/// </summary>
+public class ErrorHandlingMiddlewareTests
+{
+    private static async Task<(int Status, JsonElement Body)> RunAsync(Exception thrown)
+    {
+        RequestDelegate next = _ => throw thrown;
+        var middleware = new ErrorHandlingMiddleware(next, new NullLogger<ErrorHandlingMiddleware>());
+
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+
+        await middleware.InvokeAsync(context);
+
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        using JsonDocument doc = await JsonDocument.ParseAsync(context.Response.Body);
+        return (context.Response.StatusCode, doc.RootElement.Clone());
+    }
+
+    [Fact]
+    public async Task NotFoundException_MapsTo404WithErrorCode()
+    {
+        (int status, JsonElement body) = await RunAsync(new NotFoundException("Project not found", ErrorCodes.ProjectNotFound));
+
+        status.Should().Be((int)HttpStatusCode.NotFound);
+        body.GetProperty("success").GetBoolean().Should().BeFalse();
+        body.GetProperty("errorCode").GetString().Should().Be(ErrorCodes.ProjectNotFound);
+        body.GetProperty("message").GetString().Should().Be("Project not found");
+    }
+
+    [Fact]
+    public async Task ForbiddenException_MapsTo403()
+    {
+        (int status, JsonElement body) = await RunAsync(new ForbiddenException("nope"));
+
+        status.Should().Be((int)HttpStatusCode.Forbidden);
+        body.GetProperty("errorCode").GetString().Should().Be(ErrorCodes.PermissionDenied);
+    }
+
+    [Fact]
+    public async Task RegistryRateLimitException_MapsTo429()
+    {
+        (int status, JsonElement body) = await RunAsync(new RegistryRateLimitException("slow down"));
+
+        status.Should().Be((int)HttpStatusCode.TooManyRequests);
+        body.GetProperty("errorCode").GetString().Should().Be("REGISTRY_RATE_LIMITED");
+    }
+
+    [Fact]
+    public async Task ValidationException_MapsTo400WithFieldErrors()
+    {
+        var failures = new[] { new ValidationFailure("Name", "Name is required") };
+        (int status, JsonElement body) = await RunAsync(new ValidationException(failures));
+
+        status.Should().Be((int)HttpStatusCode.BadRequest);
+        body.GetProperty("errorCode").GetString().Should().Be("VALIDATION_ERROR");
+        body.GetProperty("errors").GetProperty("Name")[0].GetString().Should().Be("Name is required");
+    }
+
+    [Fact]
+    public async Task UnknownException_MapsTo500()
+    {
+        (int status, JsonElement body) = await RunAsync(new Exception("boom"));
+
+        status.Should().Be((int)HttpStatusCode.InternalServerError);
+        body.GetProperty("errorCode").GetString().Should().Be("INTERNAL_SERVER_ERROR");
+        // Internal errors must not leak the raw message.
+        body.GetProperty("message").GetString().Should().NotContain("boom");
+    }
+}

--- a/lighthouse-back/lighthouse-back/src/Constants/ErrorCodes.cs
+++ b/lighthouse-back/lighthouse-back/src/Constants/ErrorCodes.cs
@@ -1,0 +1,31 @@
+namespace Lighthouse.Constants;
+
+/// <summary>
+/// Machine-readable error codes returned in <c>ApiResponse.ErrorCode</c>. Centralized so the same
+/// string isn't re-typed across controllers and so the frontend can branch on stable values.
+/// </summary>
+public static class ErrorCodes
+{
+    // Generic
+    public const string ServerError = "SERVER_ERROR";
+    public const string ValidationError = "VALIDATION_ERROR";
+    public const string Unauthorized = "UNAUTHORIZED";
+    public const string BadRequest = "BAD_REQUEST";
+    public const string Conflict = "CONFLICT";
+
+    // Not found
+    public const string ResourceNotFound = "RESOURCE_NOT_FOUND";
+    public const string ProjectNotFound = "PROJECT_NOT_FOUND";
+    public const string OperationNotFound = "OPERATION_NOT_FOUND";
+    public const string FileNotFound = "FILE_NOT_FOUND";
+
+    // Permission / self-protection
+    public const string PermissionDenied = "PERMISSION_DENIED";
+    public const string SelfProjectProtected = "SELF_PROJECT_PROTECTED";
+    public const string SelfContainerProtected = "SELF_CONTAINER_PROTECTED";
+
+    // Operations
+    public const string DockerOperationFailed = "DOCKER_OPERATION_FAILED";
+    public const string OperationFailed = "OPERATION_FAILED";
+    public const string UpdateFailed = "UPDATE_FAILED";
+}

--- a/lighthouse-back/lighthouse-back/src/Exceptions/AppException.cs
+++ b/lighthouse-back/lighthouse-back/src/Exceptions/AppException.cs
@@ -1,0 +1,49 @@
+using System.Net;
+
+namespace Lighthouse.Exceptions;
+
+/// <summary>
+/// Base type for expected, domain-level failures. Carries the HTTP status and machine-readable
+/// error code that <c>ErrorHandlingMiddleware</c> maps to the API response, so domain code can
+/// <c>throw new NotFoundException(...)</c> instead of building a 500/404/etc. result by hand.
+/// </summary>
+public class AppException : Exception
+{
+    public HttpStatusCode StatusCode { get; }
+    public string ErrorCode { get; }
+
+    public AppException(HttpStatusCode statusCode, string errorCode, string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        StatusCode = statusCode;
+        ErrorCode = errorCode;
+    }
+}
+
+/// <summary>404 — the requested resource does not exist.</summary>
+public sealed class NotFoundException : AppException
+{
+    public NotFoundException(string message, string errorCode = Constants.ErrorCodes.ResourceNotFound)
+        : base(HttpStatusCode.NotFound, errorCode, message) { }
+}
+
+/// <summary>403 — the caller is authenticated but not permitted to perform the action.</summary>
+public sealed class ForbiddenException : AppException
+{
+    public ForbiddenException(string message, string errorCode = Constants.ErrorCodes.PermissionDenied)
+        : base(HttpStatusCode.Forbidden, errorCode, message) { }
+}
+
+/// <summary>409 — the request conflicts with the current state.</summary>
+public sealed class ConflictException : AppException
+{
+    public ConflictException(string message, string errorCode = Constants.ErrorCodes.Conflict)
+        : base(HttpStatusCode.Conflict, errorCode, message) { }
+}
+
+/// <summary>400 — the request is malformed or fails a domain rule.</summary>
+public sealed class BadRequestException : AppException
+{
+    public BadRequestException(string message, string errorCode = Constants.ErrorCodes.BadRequest)
+        : base(HttpStatusCode.BadRequest, errorCode, message) { }
+}

--- a/lighthouse-back/lighthouse-back/src/Middleware/ErrorHandlingMiddleware.cs
+++ b/lighthouse-back/lighthouse-back/src/Middleware/ErrorHandlingMiddleware.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Text.Json;
 using Lighthouse.DTOs;
+using Lighthouse.Exceptions;
+using Lighthouse.Services.Registry;
 using FluentValidation;
 
 namespace Lighthouse.Middleware;
@@ -38,6 +40,19 @@ public class ErrorHandlingMiddleware
 
         switch (exception)
         {
+            // Domain failures carry their own status + error code.
+            case AppException appException:
+                statusCode = appException.StatusCode;
+                errorCode = appException.ErrorCode;
+                message = appException.Message;
+                break;
+
+            case RegistryRateLimitException:
+                statusCode = HttpStatusCode.TooManyRequests;
+                errorCode = "REGISTRY_RATE_LIMITED";
+                message = exception.Message;
+                break;
+
             case ValidationException validationException:
                 statusCode = HttpStatusCode.BadRequest;
                 errorCode = "VALIDATION_ERROR";


### PR DESCRIPTION
Closes out the backend structural work. `ErrorHandlingMiddleware` already existed and mapped validation / argument / not-found / unauthorized / invalid-operation → consistent `ApiResponse.Fail`. This adds the missing **semantic layer**.

## Added
- **`AppException`** base (carries `HttpStatusCode` + `ErrorCode`) with `NotFoundException` (404), `ForbiddenException` (403), `ConflictException` (409), `BadRequestException` (400). Domain code can now `throw new NotFoundException("Project not found", ErrorCodes.ProjectNotFound)` instead of hand-building a status result.
- **`ErrorCodes`** constants centralizing the codes currently duplicated as magic strings across controllers (`SERVER_ERROR` ×35, `PERMISSION_DENIED` ×16, `DOCKER_OPERATION_FAILED` ×16, `RESOURCE_NOT_FOUND`, `SELF_*_PROTECTED`, …).
- Middleware now maps `AppException` (its own status/code/message) and `RegistryRateLimitException` → **429**, ahead of the existing cases.

## Scope / risk
**Purely additive** — existing code doesn't throw `AppException`, so behaviour is unchanged. I deliberately did **not** rewrite the ~130 `catch (Exception) → 500` blocks: adopting domain exceptions means *removing* the surrounding try/catch (otherwise it swallows the exception into a 500), which is exactly the risky mass rewrite. The infra is in place; adoption can be incremental, file by file, with its own tests.

## Tests
`ErrorHandlingMiddlewareTests` (5): NotFound→404, Forbidden→403, registry→429, validation→400 with field errors, unknown→500 **without leaking the raw message**.

## Verification
- `dotnet build -c Release` → 0 warnings, 0 errors.
- `dotnet test` → 334 passed (3 integration skipped).

## Remaining pass items
- **PR8** — frontend component splits + store consolidation
- **PR9** — docs consolidation + CI `actions/checkout@v5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)