### PR TITLE
test/refactor: frontend store tests + safe cleanups (PR8a)

### DIFF
--- a/lighthouse-front/src/lib/components/common/ActivityItem.svelte
+++ b/lighthouse-front/src/lib/components/common/ActivityItem.svelte
@@ -4,7 +4,6 @@
   import { enUS, fr, es } from 'date-fns/locale';
   import { t, locale as localeStore } from '$lib/i18n';
   import type { Activity } from '$lib/api/dashboard';
-  import { get } from 'svelte/store';
 
   interface Props {
     item: Activity;
@@ -22,7 +21,7 @@
   const localeMap: Record<string, typeof enUS> = { en: enUS, fr, es };
 
   const resourceIcon = $derived(iconMap[item.resourceType] || null);
-  const currentLocaleCode = $derived(get(localeStore));
+  const currentLocaleCode = $derived($localeStore);
   const currentLocale = $derived(localeMap[currentLocaleCode] || enUS);
   const timeAgo = $derived(formatDistanceToNow(new Date(item.timestamp), {
     addSuffix: true,

--- a/lighthouse-front/src/lib/stores/batchOperation.test.ts
+++ b/lighthouse-front/src/lib/stores/batchOperation.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  isBatchOperationActive,
+  isProjectUpdating,
+  getActiveOperationCount,
+  startBatchOperation,
+  endBatchOperation,
+  clearAllBatchOperations
+} from './batchOperation.svelte';
+
+describe('batchOperation store', () => {
+  beforeEach(() => clearAllBatchOperations());
+
+  it('tracks active operations', () => {
+    expect(isBatchOperationActive()).toBe(false);
+
+    startBatchOperation('op1');
+    expect(isBatchOperationActive()).toBe(true);
+    expect(getActiveOperationCount()).toBe(1);
+  });
+
+  it('tracks per-project updating state', () => {
+    startBatchOperation('op1', 'proj');
+    expect(isProjectUpdating('proj')).toBe(true);
+    expect(isProjectUpdating('other')).toBe(false);
+  });
+
+  it('returns a cleanup function that ends the operation', () => {
+    const cleanup = startBatchOperation('op1', 'proj');
+    cleanup();
+    expect(isBatchOperationActive()).toBe(false);
+    expect(isProjectUpdating('proj')).toBe(false);
+  });
+
+  it('ends a specific operation', () => {
+    startBatchOperation('op1');
+    startBatchOperation('op2');
+    endBatchOperation('op1');
+    expect(getActiveOperationCount()).toBe(1);
+  });
+
+  it('clears everything', () => {
+    startBatchOperation('op1', 'proj');
+    clearAllBatchOperations();
+    expect(isBatchOperationActive()).toBe(false);
+    expect(isProjectUpdating('proj')).toBe(false);
+  });
+});

--- a/lighthouse-front/src/lib/stores/containerUpdate.test.ts
+++ b/lighthouse-front/src/lib/stores/containerUpdate.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('$app/environment', () => ({ browser: false }));
+vi.mock('$lib/api/update', () => ({ updateApi: {} }));
+
+import {
+  containerUpdateState,
+  hasAnyContainerUpdates,
+  containersWithUpdatesCount,
+  containerHasUpdate,
+  setContainerUpdateResult,
+  markContainerAsUpdated,
+  handleContainerUpdatesCheckedEvent,
+  reconcileContainerUpdateState,
+  clearContainerUpdateState
+} from './containerUpdate.svelte';
+
+describe('containerUpdate store', () => {
+  beforeEach(() => clearContainerUpdateState());
+
+  it('tracks per-container update results', () => {
+    setContainerUpdateResult('a', true);
+    setContainerUpdateResult('b', false);
+
+    expect(containerHasUpdate('a')).toBe(true);
+    expect(containerHasUpdate('b')).toBe(false);
+    expect(containerHasUpdate('unknown')).toBe(false);
+    expect(hasAnyContainerUpdates.current).toBe(true);
+    expect(containersWithUpdatesCount.current).toBe(1);
+  });
+
+  it('marks a container as updated', () => {
+    setContainerUpdateResult('a', true);
+    markContainerAsUpdated('a');
+    expect(containerHasUpdate('a')).toBe(false);
+    expect(hasAnyContainerUpdates.current).toBe(false);
+  });
+
+  it('applies an SSE checked event', () => {
+    handleContainerUpdatesCheckedEvent({
+      containersWithUpdates: 1,
+      containers: [
+        { containerId: 'a', updateAvailable: true },
+        { containerId: 'b', updateAvailable: false }
+      ]
+    } as never);
+
+    expect(containerHasUpdate('a')).toBe(true);
+    expect(containerHasUpdate('b')).toBe(false);
+    expect(containerUpdateState.lastChecked).toBeInstanceOf(Date);
+  });
+
+  it('reconciles away stale containers', () => {
+    setContainerUpdateResult('a', true);
+    setContainerUpdateResult('b', true);
+
+    reconcileContainerUpdateState(new Set(['a']));
+
+    expect(containerHasUpdate('a')).toBe(true);
+    expect('b' in containerUpdateState.containersWithUpdates).toBe(false);
+  });
+
+  it('clears all state', () => {
+    setContainerUpdateResult('a', true);
+    clearContainerUpdateState();
+    expect(containersWithUpdatesCount.current).toBe(0);
+    expect(containerUpdateState.lastChecked).toBeNull();
+  });
+});

--- a/lighthouse-front/src/lib/stores/crashLoop.test.ts
+++ b/lighthouse-front/src/lib/stores/crashLoop.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  setCrashLooping,
+  clearCrashLooping,
+  clearAllCrashLooping,
+  isCrashLooping,
+  syncFromContainers,
+  syncFromProjects
+} from './crashLoop.svelte';
+
+describe('crashLoop store', () => {
+  beforeEach(() => clearAllCrashLooping());
+
+  it('sets and clears crash-loop state by entity key', () => {
+    setCrashLooping('container:c1');
+    expect(isCrashLooping('container', 'c1')).toBe(true);
+
+    clearCrashLooping('container:c1');
+    expect(isCrashLooping('container', 'c1')).toBe(false);
+  });
+
+  it('distinguishes projects from containers', () => {
+    setCrashLooping('project:p1');
+    expect(isCrashLooping('project', 'p1')).toBe(true);
+    expect(isCrashLooping('container', 'p1')).toBe(false);
+  });
+
+  it('syncs from container API data', () => {
+    syncFromContainers([
+      { id: 'c1', isCrashLooping: true },
+      { id: 'c2', isCrashLooping: false }
+    ] as never);
+
+    expect(isCrashLooping('container', 'c1')).toBe(true);
+    expect(isCrashLooping('container', 'c2')).toBe(false);
+  });
+
+  it('syncs projects and their services', () => {
+    syncFromProjects([
+      {
+        name: 'p1',
+        isCrashLooping: true,
+        services: [{ id: 'svc1', isCrashLooping: true }]
+      }
+    ] as never);
+
+    expect(isCrashLooping('project', 'p1')).toBe(true);
+    expect(isCrashLooping('container', 'svc1')).toBe(true);
+  });
+});

--- a/lighthouse-front/src/lib/stores/index.ts
+++ b/lighthouse-front/src/lib/stores/index.ts
@@ -1,6 +1,18 @@
+// Barrel for the Svelte 5 rune stores. Each store is re-exported as a namespace so
+// callers can `import { theme } from '$lib/stores'` (or keep importing the module
+// directly). Type-only re-exports are listed alongside their store.
 export * as auth from './auth.svelte';
 export * as compose from './compose.svelte';
 export * as theme from './theme.svelte';
 export type { Theme } from './theme.svelte';
 export * as sse from './sse.svelte';
 export type { ConnectionStatus } from './sse.svelte';
+export * as actionLog from './actionLog.svelte';
+export * as autoUpdate from './autoUpdate.svelte';
+export * as batchOperation from './batchOperation.svelte';
+export * as columnPreferences from './columnPreferences.svelte';
+export * as containerUpdate from './containerUpdate.svelte';
+export * as crashLoop from './crashLoop.svelte';
+export * as notifications from './notifications.svelte';
+export * as projectUpdate from './projectUpdate.svelte';
+export * as update from './update.svelte';

--- a/lighthouse-front/src/routes/(protected)/audit/+page.svelte
+++ b/lighthouse-front/src/routes/(protected)/audit/+page.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
   import { createQuery, createMutation, useQueryClient } from '@tanstack/svelte-query';
-  import { ClipboardList, Search, Filter, Trash2, BarChart3, RefreshCw } from 'lucide-svelte';
+  import { ClipboardList, Search, Filter, Trash2, RefreshCw } from 'lucide-svelte';
   import { auditApi } from '$lib/api';
   import type { AuditLog } from '$lib/types';
   import { AuditSortField, SortOrder } from '$lib/types/audit';
   import LoadingState from '$lib/components/common/LoadingState.svelte';
   import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
-  import StatsCard from '$lib/components/common/StatsCard.svelte';
   import Input from '$lib/components/ui/input.svelte';
   import Select from '$lib/components/ui/select.svelte';
   import Badge from '$lib/components/ui/badge.svelte';
@@ -57,12 +56,6 @@
     queryKey: ['audit', 'distinctResourceTypes'],
     queryFn: () => auditApi.getDistinctResourceTypes(),
   }));
-
-  // TODO: Implement /api/audit/stats endpoint in backend
-  // const statsQuery = createQuery(() => ({
-  //   queryKey: ['audit', 'stats'],
-  //   queryFn: () => auditApi.getAuditStats(),
-  // }));
 
   const purgeMutation = createMutation(() => ({
     mutationFn: (daysOld: number) => auditApi.purgeOldLogs({ olderThanDays: daysOld }),
@@ -150,33 +143,6 @@
       </Button>
     </div>
   </div>
-
-  <!-- Statistics -->
-  <!-- TODO: Uncomment when /api/audit/stats endpoint is implemented in backend -->
-  <!-- {#if statsQuery.data}
-    <div class="grid gap-4 md:grid-cols-4">
-      <StatsCard
-        title="Total Logs"
-        value={statsQuery.data.totalLogs.toString()}
-        icon={BarChart3}
-      />
-      <StatsCard
-        title="Today"
-        value={statsQuery.data.logsToday.toString()}
-        icon={ClipboardList}
-      />
-      <StatsCard
-        title="This Week"
-        value={statsQuery.data.logsThisWeek.toString()}
-        icon={ClipboardList}
-      />
-      <StatsCard
-        title="This Month"
-        value={statsQuery.data.logsThisMonth.toString()}
-        icon={ClipboardList}
-      />
-    </div>
-  {/if} -->
 
   <!-- Filter Panel -->
   <div class="p-6 bg-gradient-to-br from-white to-gray-50 dark:from-gray-800 dark:to-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 shadow-lg">


### PR DESCRIPTION
First frontend pass — the **safe, fully-verifiable** half. The big interactive component splits (settings 913, compose-projects 794, update dialogs) are **deferred**: I can verify types/lint/build/unit-tests here but not visual rendering, and they need a manual browser check.

## Added test coverage (the untested pure stores)
- `containerUpdate` (5), `crashLoop` (4), `batchOperation` (5) — **14 new vitest tests** on the pure rune-state logic (set/clear/SSE-apply/reconcile/cleanup). Confirmed runes (`$state`) compile and run under vitest.

## Cleanups
- **`stores/index.ts`**: completed the barrel — all rune stores re-exported as namespaces (was only `auth`/`compose`/`theme`/`sse`).
- **`ActivityItem.svelte`**: replaced the legacy `get(localeStore)` with the reactive `$localeStore` auto-subscription, so the relative timestamp re-localizes when the language changes (removed the `svelte/store` `get` import).
- **Audit page**: removed the dead `/api/audit/stats` TODO (commented query + commented stats UI) and the now-orphaned `BarChart3` / `StatsCard` imports.

## Not done (intentionally)
The three update stores (`update` / `projectUpdate` / `containerUpdate`) are **distinct domains** (app self-update vs compose-project vs container), not duplicates — consolidating them would be wrong, so they're left as-is.

## Verification
- `npm run check` → 0 errors.
- `npm run lint` → 0 errors (185 warnings = pre-existing backlog).
- `npm test` → **22 passed**.
- `npm run build` → ok.

## Deferred to when manual verification is possible
- Split settings / compose-projects pages into section components.
- Extract shared update-dialog logic (Service/Container/Bulk) into a `useUpdateProgress` rune + shared sub-components.
- Repo-wide `npm run format` (prettier) — best run last to avoid churn collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)