### PR TITLE
ci: add Dependabot config for weekly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+updates:
+  # Backend .NET (NuGet)
+  - package-ecosystem: "nuget"
+    directory: "/lighthouse-back"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      nuget-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # Frontend (npm)
+  - package-ecosystem: "npm"
+    directory: "/lighthouse-front"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # Docker base images
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/.devcontainer"
+      - "/debug"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+
+  # GitHub Actions (workflows + composite actions)
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "/.github/actions/setup-dotnet"
+      - "/.github/actions/setup-node"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to automate dependency update PRs, checked weekly (Mondays):

- **NuGet** (`lighthouse-back/`) — minor+patch grouped into a single PR, majors individual
- **npm** (`lighthouse-front/`) — minor+patch grouped, majors individual
- **Docker** base images — root `Dockerfile`, `.devcontainer/Dockerfile`, `debug/Dockerfile.debug`
- **GitHub Actions** — workflows plus composite actions (`setup-dotnet`, `setup-node`)

`open-pull-requests-limit: 3` per ecosystem to keep noise low.

## Notes

- No `release-*` label is applied to Dependabot PRs, so merging them does not trigger a release (per RELEASING.md). Dependency bumps ship with the next regular release.
- No auto-merge: Dependabot PRs go through normal manual review; `pr-ci.yml` validates them like any other PR.
- After merge, check **Insights → Dependency graph → Dependabot** to see per-ecosystem jobs; a manual "Check for updates" can be triggered there to test without waiting for Monday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
