### PR TITLE
ci: group all Docker and GitHub Actions updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,9 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 3
+    groups:
+      docker-all:
+        patterns: ["*"]
 
   # GitHub Actions (workflows + composite actions)
   - package-ecosystem: "github-actions"
@@ -43,3 +46,6 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 3
+    groups:
+      actions-all:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary

Follow-up to #142. The first Dependabot run opened one PR per dependency for the `docker` and `github-actions` ecosystems because only `nuget`/`npm` had groups configured.

This adds a catch-all group (`patterns: ["*"]`, majors included) for both ecosystems:

- `docker-all` — all Docker base image bumps in a single weekly PR
- `actions-all` — all GitHub Actions bumps in a single weekly PR

These updates are low-risk and trivial to review, so grouping majors there is fine. NuGet/npm keep their minor+patch-only groups: majors stay individual for careful review.

## Effect on existing PRs

On its next run, Dependabot will close the currently open individual PRs (#143–#146) and replace them with grouped ones. You can trigger this manually via **Insights → Dependency graph → Dependabot → Check for updates** after merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
