### PR TITLE
fix(ci): exclude underscores from sanitized branch tag

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -93,7 +93,9 @@ jobs:
         run: |
           # Get branch name and replace / with -
           BRANCH_NAME="${{ github.head_ref }}"
-          SANITIZED_BRANCH=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//')
+          # Underscores excluded: the tag is also used as the NuGet /p:Version
+          # prerelease suffix, where SemVer forbids '_' (e.g. dependabot/github_actions/* branches)
+          SANITIZED_BRANCH=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9.-]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//')
           echo "tag=$SANITIZED_BRANCH" >> $GITHUB_OUTPUT
           echo "Branch: $BRANCH_NAME -> Tag: $SANITIZED_BRANCH"
 


### PR DESCRIPTION
## Summary

Dependabot branches such as `dependabot/github_actions/...` and `dependabot/npm_and_yarn/...` contain underscores. The "Sanitize branch name" step in `pr-ci.yml` allowed `_` through, and the resulting tag is injected into `dotnet publish /p:Version=...`. SemVer/NuGet forbids underscores in prerelease identifiers, so the Docker build failed on those PRs:

```
error : '1.24.3-dependabot-github_actions-actions-all-ed28b5ff9c' is not a valid version string. (Parameter 'value')
```

## Fix

Exclude `_` from the allowed character class so underscores are mapped to hyphens — valid for both Docker tags and NuGet version strings:

```diff
- sed 's/[^a-zA-Z0-9._-]/-/g'
+ sed 's/[^a-zA-Z0-9.-]/-/g'
```

Affected open PRs: #152 (github-actions group) failed, #147 (npm) would fail the same way. After this merges, commenting `@dependabot rebase` on them will re-run CI on top of the fix.

## Labels

No `release-*` label: CI-only change, no release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
