### PR TITLE
fix(deps): replace vulnerable SQLitePCLRaw.lib.e_sqlite3 with SourceGear.sqlite3

### DIFF
--- a/lighthouse-back/lighthouse-back/lighthouse-back.csproj
+++ b/lighthouse-back/lighthouse-back/lighthouse-back.csproj
@@ -37,6 +37,13 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <!--
+      Override the transitive SQLitePCLRaw.bundle_e_sqlite3 2.1.11 pulled by EF Core,
+      which depends on the deprecated SQLitePCLRaw.lib.e_sqlite3 (CVE-2025-6965,
+      SQLite < 3.50.2). Bundle 3.x replaces it with SourceGear.sqlite3 (patched SQLite).
+      See https://github.com/ericsink/SQLitePCL.raw/wiki/Package-ID-change:-SQLitePCLRaw.lib.e_sqlite3-is-now-SourceGear.sqlite3
+    -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />


### PR DESCRIPTION
## Problem

`dotnet list package --vulnerable` flags a transitive dependency:

- **`SQLitePCLRaw.lib.e_sqlite3` 2.1.11** — **CVE-2025-6965** ([GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q), high severity). SQLite < 3.50.2 memory corruption (aggregate terms can exceed available columns).

It is pulled in transitively by `Microsoft.EntityFrameworkCore.Sqlite` → `SQLitePCLRaw.bundle_e_sqlite3` 2.1.11 → `SQLitePCLRaw.lib.e_sqlite3` 2.1.11. The package is now deprecated on NuGet and its ID was reassigned to `SourceGear.sqlite3`.

## Fix

Add a direct reference to **`SQLitePCLRaw.bundle_e_sqlite3` 3.0.3**, overriding the transitive 2.1.11. The 3.x bundle line replaces `lib.e_sqlite3` with **`SourceGear.sqlite3` 3.50.4.5** (SQLite 3.50.4, patched). This is the migration path [recommended by the SQLitePCL.raw maintainer](https://github.com/ericsink/SQLitePCL.raw/wiki/Package-ID-change:-SQLitePCLRaw.lib.e_sqlite3-is-now-SourceGear.sqlite3) after the package ID reassignment — preferred over referencing `SourceGear.sqlite3` directly, which would leave the deprecated `lib.e_sqlite3` in the graph and risk a duplicate native asset.

One line of `csproj` (plus an explanatory comment); no code changes.

## Verification

- `dotnet list package --include-transitive --vulnerable` → **no vulnerable packages**; `lib.e_sqlite3` gone, `SourceGear.sqlite3` 3.50.4.5 present.
- Isolated smoke loads the native library and reports **SQLite 3.50.4** (≥ 3.50.2).
- `dotnet build -c Release` → 0 warnings (NU1903 cleared).
- Full backend test suite (**334**) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)