### PR TITLE
feat(images): scheduled auto-prune of unused images

### DIFF
--- a/lighthouse-back/lighthouse-back/src/Controllers/ConfigController.cs
+++ b/lighthouse-back/lighthouse-back/src/Controllers/ConfigController.cs
@@ -336,7 +336,9 @@ public class ConfigController : BaseController
         }
 
         if (key == AutoUpdateComposeBackgroundService.EnabledKey
-            || key == AutoUpdateAppBackgroundService.EnabledKey)
+            || key == AutoUpdateAppBackgroundService.EnabledKey
+            || key == AutoPruneImagesBackgroundService.EnabledKey
+            || key == AutoPruneImagesBackgroundService.DanglingOnlyKey)
         {
             if (!bool.TryParse(value, out _))
             {
@@ -346,7 +348,8 @@ public class ConfigController : BaseController
         }
 
         if (key == AutoUpdateComposeBackgroundService.CronKey
-            || key == AutoUpdateAppBackgroundService.CronKey)
+            || key == AutoUpdateAppBackgroundService.CronKey
+            || key == AutoPruneImagesBackgroundService.CronKey)
         {
             try
             {

--- a/lighthouse-back/lighthouse-back/src/Extensions/ServiceCollectionExtensions.cs
+++ b/lighthouse-back/lighthouse-back/src/Extensions/ServiceCollectionExtensions.cs
@@ -143,6 +143,7 @@ public static class ServiceCollectionExtensions
         services.AddHostedService<ProjectUpdateCheckBackgroundService>();
         services.AddHostedService<AutoUpdateComposeBackgroundService>();
         services.AddHostedService<AutoUpdateAppBackgroundService>();
+        services.AddHostedService<AutoPruneImagesBackgroundService>();
         services.AddHostedService<AppUpdateNotificationStartupService>();
         services.AddHostedService<Lighthouse.BackgroundServices.CleanupBackgroundService>();
         return services;

--- a/lighthouse-back/lighthouse-back/src/Services/AuditService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/AuditService.cs
@@ -363,6 +363,7 @@ public static class AuditActions
     // Image actions
     public const string ImageRemove = "image.remove";
     public const string ImagePrune = "image.prune";
+    public const string AutoPruneImages = "auto_prune.images";
 
     // Compose file actions
     public const string FileCreate = "file.create";

--- a/lighthouse-back/lighthouse-back/src/Services/AutoPruneImagesBackgroundService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/AutoPruneImagesBackgroundService.cs
@@ -136,7 +136,7 @@ public class AutoPruneImagesBackgroundService : BackgroundService
 
                 // Best-effort Discord summary, mirroring the compose auto-update flow.
                 await notificationService.NotifyImagePruneAsync(
-                    result.ImagesDeleted.Count, result.SpaceReclaimed, danglingOnly, ct);
+                    result.ImagesDeleted, result.SpaceReclaimed, danglingOnly, ct);
             }
         }
         catch (Exception ex)

--- a/lighthouse-back/lighthouse-back/src/Services/AutoPruneImagesBackgroundService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/AutoPruneImagesBackgroundService.cs
@@ -1,0 +1,191 @@
+using Cronos;
+using Lighthouse.Data;
+using Lighthouse.DTOs;
+using Lighthouse.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lighthouse.Services;
+
+/// <summary>
+/// Background service that prunes unused Docker images on a cron schedule.
+/// Disabled by default. Prunes dangling images only unless configured otherwise.
+/// Skips a cycle while a self-update is in progress (the new image may not yet be
+/// referenced by a container and could otherwise be pruned).
+/// </summary>
+public class AutoPruneImagesBackgroundService : BackgroundService
+{
+    public const string EnabledKey = "AutoPruneImagesEnabled";
+    public const string CronKey = "AutoPruneImagesCron";
+    public const string DanglingOnlyKey = "AutoPruneImagesDanglingOnly";
+    public const string DefaultCron = "0 3 * * *";
+
+    // Short fixed tick: every tick we check whether a cron occurrence fell within the
+    // elapsed window. This never misses the scheduled minute and picks up enable/cron
+    // changes within one tick.
+    private static readonly TimeSpan TickInterval = TimeSpan.FromSeconds(20);
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly SseConnectionManagerService _sse;
+    private readonly ILogger<AutoPruneImagesBackgroundService> _logger;
+    private readonly SemaphoreSlim _cycleLock = new(1, 1);
+
+    public AutoPruneImagesBackgroundService(
+        IServiceProvider serviceProvider,
+        SseConnectionManagerService sse,
+        ILogger<AutoPruneImagesBackgroundService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _sse = sse;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("AutoPruneImagesBackgroundService starting");
+
+        DateTime lastCheckUtc = DateTime.UtcNow;
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(TickInterval, stoppingToken);
+
+                (bool enabled, string cron, bool danglingOnly) = await ReadSettingsAsync(stoppingToken);
+                DateTime nowUtc = DateTime.UtcNow;
+
+                if (!enabled)
+                {
+                    lastCheckUtc = nowUtc;
+                    continue;
+                }
+
+                if (!TryParseCron(cron, out CronExpression? expression))
+                {
+                    _logger.LogWarning("Invalid cron expression '{Cron}' for AutoPruneImages.", cron);
+                    lastCheckUtc = nowUtc;
+                    continue;
+                }
+
+                DateTime? occurrence = expression!.GetNextOccurrence(lastCheckUtc, inclusive: false);
+                if (occurrence.HasValue && occurrence.Value <= nowUtc)
+                {
+                    _logger.LogInformation("AutoPruneImages: scheduled occurrence {Occurrence:O} is due, running cycle", occurrence.Value);
+                    await RunCycleAsync(danglingOnly, stoppingToken);
+                }
+
+                lastCheckUtc = nowUtc;
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in AutoPruneImagesBackgroundService loop");
+            }
+        }
+
+        _logger.LogInformation("AutoPruneImagesBackgroundService stopped");
+    }
+
+    private async Task RunCycleAsync(bool danglingOnly, CancellationToken ct)
+    {
+        if (!await _cycleLock.WaitAsync(0, ct))
+        {
+            _logger.LogDebug("Auto-prune cycle already in progress, skipping");
+            return;
+        }
+
+        try
+        {
+            using IServiceScope scope = _serviceProvider.CreateScope();
+
+            ISelfUpdateService selfUpdateService = scope.ServiceProvider.GetRequiredService<ISelfUpdateService>();
+            if (selfUpdateService.IsUpdateInProgress)
+            {
+                _logger.LogInformation("Self-update in progress, deferring auto-prune cycle");
+                return;
+            }
+
+            IImageService imageService = scope.ServiceProvider.GetRequiredService<IImageService>();
+            IAuditService auditService = scope.ServiceProvider.GetRequiredService<IAuditService>();
+
+            PruneImagesResultDto result = await imageService.PruneImagesAsync(danglingOnly, ct);
+
+            _logger.LogInformation(
+                "AutoPruneImages cycle complete: {Count} image(s) removed, {Bytes} bytes reclaimed (danglingOnly={DanglingOnly})",
+                result.ImagesDeleted.Count, result.SpaceReclaimed, danglingOnly);
+
+            await auditService.LogActionAsync(
+                userId: null,
+                action: AuditActions.AutoPruneImages,
+                ipAddress: "system",
+                details: $"Removed {result.ImagesDeleted.Count} image(s), reclaimed {result.SpaceReclaimed} bytes (danglingOnly={danglingOnly})",
+                resourceType: "image");
+
+            if (result.ImagesDeleted.Count > 0)
+            {
+                await _sse.BroadcastAsync("ImagesChanged", new
+                {
+                    action = "prune",
+                    timestamp = DateTime.UtcNow
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error running auto-prune cycle");
+        }
+        finally
+        {
+            _cycleLock.Release();
+        }
+    }
+
+    private async Task<(bool Enabled, string Cron, bool DanglingOnly)> ReadSettingsAsync(CancellationToken ct)
+    {
+        try
+        {
+            using IServiceScope scope = _serviceProvider.CreateScope();
+            AppDbContext db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+            AppSetting? enabledSetting = await db.AppSettings.FirstOrDefaultAsync(s => s.Key == EnabledKey, ct);
+            AppSetting? cronSetting = await db.AppSettings.FirstOrDefaultAsync(s => s.Key == CronKey, ct);
+            AppSetting? danglingSetting = await db.AppSettings.FirstOrDefaultAsync(s => s.Key == DanglingOnlyKey, ct);
+
+            bool enabled = enabledSetting != null
+                && bool.TryParse(enabledSetting.Value, out bool b)
+                && b;
+
+            string cron = !string.IsNullOrWhiteSpace(cronSetting?.Value) ? cronSetting!.Value : DefaultCron;
+
+            // Default to dangling-only (safe) when the setting is absent.
+            bool danglingOnly = danglingSetting == null
+                || !bool.TryParse(danglingSetting.Value, out bool d)
+                || d;
+
+            return (enabled, cron, danglingOnly);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read AutoPruneImages settings; treating as disabled");
+            return (false, DefaultCron, true);
+        }
+    }
+
+    private static bool TryParseCron(string expression, out CronExpression? parsed)
+    {
+        try
+        {
+            CronFormat format = expression.Trim().Split(' ').Length == 6 ? CronFormat.IncludeSeconds : CronFormat.Standard;
+            parsed = CronExpression.Parse(expression, format);
+            return true;
+        }
+        catch
+        {
+            parsed = null;
+            return false;
+        }
+    }
+}

--- a/lighthouse-back/lighthouse-back/src/Services/AutoPruneImagesBackgroundService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/AutoPruneImagesBackgroundService.cs
@@ -2,6 +2,7 @@ using Cronos;
 using Lighthouse.Data;
 using Lighthouse.DTOs;
 using Lighthouse.Models;
+using Lighthouse.Services.Notifications;
 using Microsoft.EntityFrameworkCore;
 
 namespace Lighthouse.Services;
@@ -110,6 +111,7 @@ public class AutoPruneImagesBackgroundService : BackgroundService
 
             IImageService imageService = scope.ServiceProvider.GetRequiredService<IImageService>();
             IAuditService auditService = scope.ServiceProvider.GetRequiredService<IAuditService>();
+            INotificationService notificationService = scope.ServiceProvider.GetRequiredService<INotificationService>();
 
             PruneImagesResultDto result = await imageService.PruneImagesAsync(danglingOnly, ct);
 
@@ -131,6 +133,10 @@ public class AutoPruneImagesBackgroundService : BackgroundService
                     action = "prune",
                     timestamp = DateTime.UtcNow
                 });
+
+                // Best-effort Discord summary, mirroring the compose auto-update flow.
+                await notificationService.NotifyImagePruneAsync(
+                    result.ImagesDeleted.Count, result.SpaceReclaimed, danglingOnly, ct);
             }
         }
         catch (Exception ex)

--- a/lighthouse-back/lighthouse-back/src/Services/Notifications/DiscordNotificationService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/Notifications/DiscordNotificationService.cs
@@ -134,6 +134,23 @@ public class DiscordNotificationService : INotificationService
         return SendEmbedAsync(embed, ct);
     }
 
+    public Task NotifyImagePruneAsync(int removedCount, long spaceReclaimed, bool danglingOnly, CancellationToken ct = default)
+    {
+        if (removedCount <= 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        var embed = new DiscordEmbed
+        {
+            Title = $"🧹 Image auto-prune — {removedCount} removed",
+            Description = $"Reclaimed **{FormatBytes(spaceReclaimed)}** · {(danglingOnly ? "dangling images only" : "all unused images")}.",
+            Color = ColorSuccess,
+            Timestamp = DateTime.UtcNow
+        };
+        return SendEmbedAsync(embed, ct);
+    }
+
     public async Task<NotificationTestResult> SendTestAsync(string? overrideWebhookUrl, CancellationToken ct = default)
     {
         string? webhookUrl = !string.IsNullOrWhiteSpace(overrideWebhookUrl)
@@ -220,6 +237,19 @@ public class DiscordNotificationService : INotificationService
     {
         AppSetting? setting = await _db.AppSettings.AsNoTracking().FirstOrDefaultAsync(s => s.Key == key, ct);
         return setting?.Value;
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        string[] units = { "B", "KB", "MB", "GB", "TB" };
+        double size = bytes;
+        int u = 0;
+        while (size >= 1024 && u < units.Length - 1)
+        {
+            size /= 1024;
+            u++;
+        }
+        return $"{size:0.##} {units[u]}";
     }
 
     private static string Truncate(string value, int max)

--- a/lighthouse-back/lighthouse-back/src/Services/Notifications/DiscordNotificationService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/Notifications/DiscordNotificationService.cs
@@ -134,21 +134,46 @@ public class DiscordNotificationService : INotificationService
         return SendEmbedAsync(embed, ct);
     }
 
-    public Task NotifyImagePruneAsync(int removedCount, long spaceReclaimed, bool danglingOnly, CancellationToken ct = default)
+    public Task NotifyImagePruneAsync(IReadOnlyList<string> images, long spaceReclaimed, bool danglingOnly, CancellationToken ct = default)
     {
-        if (removedCount <= 0)
+        if (images == null || images.Count == 0)
         {
             return Task.CompletedTask;
         }
 
         var embed = new DiscordEmbed
         {
-            Title = $"🧹 Image auto-prune — {removedCount} removed",
+            Title = $"🧹 Image auto-prune — {images.Count} removed",
             Description = $"Reclaimed **{FormatBytes(spaceReclaimed)}** · {(danglingOnly ? "dangling images only" : "all unused images")}.",
             Color = ColorSuccess,
             Timestamp = DateTime.UtcNow
         };
+
+        const int maxLines = 20;
+        var sb = new StringBuilder();
+        foreach (string entry in images.Take(maxLines))
+        {
+            sb.AppendLine($"• `{FormatImageRef(entry)}`");
+        }
+        if (images.Count > maxLines)
+        {
+            sb.AppendLine($"… +{images.Count - maxLines} more");
+        }
+        embed.Fields.Add(new DiscordField("Removed", Truncate(sb.ToString().TrimEnd(), MaxFieldValueLength), false));
+
         return SendEmbedAsync(embed, ct);
+    }
+
+    /// <summary>Shortens a sha256 reference to 12 chars; leaves repo:tag names as-is.</summary>
+    private static string FormatImageRef(string entry)
+    {
+        const string prefix = "sha256:";
+        if (entry.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            string hex = entry[prefix.Length..];
+            return hex.Length > 12 ? hex[..12] : hex;
+        }
+        return entry;
     }
 
     public async Task<NotificationTestResult> SendTestAsync(string? overrideWebhookUrl, CancellationToken ct = default)

--- a/lighthouse-back/lighthouse-back/src/Services/Notifications/INotificationService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/Notifications/INotificationService.cs
@@ -33,8 +33,10 @@ public interface INotificationService
 
     /// <summary>
     /// Notify that an automatic image-prune cycle removed one or more images.
+    /// <paramref name="images"/> holds the removed references (repo:tag when
+    /// available, otherwise a sha256 id for dangling images).
     /// </summary>
-    Task NotifyImagePruneAsync(int removedCount, long spaceReclaimed, bool danglingOnly, CancellationToken ct = default);
+    Task NotifyImagePruneAsync(IReadOnlyList<string> images, long spaceReclaimed, bool danglingOnly, CancellationToken ct = default);
 
     /// <summary>
     /// Send a test notification to verify the configuration. When

--- a/lighthouse-back/lighthouse-back/src/Services/Notifications/INotificationService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/Notifications/INotificationService.cs
@@ -32,6 +32,11 @@ public interface INotificationService
     Task NotifyComposeAutoUpdateAsync(ComposeAutoUpdateReport report, CancellationToken ct = default);
 
     /// <summary>
+    /// Notify that an automatic image-prune cycle removed one or more images.
+    /// </summary>
+    Task NotifyImagePruneAsync(int removedCount, long spaceReclaimed, bool danglingOnly, CancellationToken ct = default);
+
+    /// <summary>
     /// Send a test notification to verify the configuration. When
     /// <paramref name="overrideWebhookUrl"/> is provided it is tested instead of
     /// the saved one (lets the user verify before saving).

--- a/lighthouse-front/src/lib/i18n/en.ts
+++ b/lighthouse-front/src/lib/i18n/en.ts
@@ -400,6 +400,14 @@ export default {
     checkInterval: 'Check Interval',
     intervalSaved: 'Check interval saved',
     // Auto-update settings
+    autoPrune: {
+      title: 'Auto Prune Images',
+      description: 'Automatically remove unused Docker images on a schedule to reclaim disk space. Images in use by a container (including Lighthouse itself) are never removed.',
+      enableLabel: 'Enable automatic image pruning',
+      danglingOnlyLabel: 'Dangling images only',
+      danglingOnlyHint: 'Off: remove every image not used by any container.',
+      cronLabel: 'Schedule (cron expression)',
+    },
     autoUpdate: {
       composeTitle: 'Auto Update',
       composeDescription: 'Automatically pull updated images and recreate containers for compose projects on a schedule. Exclude a project by adding "x-auto-update: false" at the root of its compose file.',

--- a/lighthouse-front/src/lib/i18n/es.ts
+++ b/lighthouse-front/src/lib/i18n/es.ts
@@ -453,6 +453,14 @@ const es = {
       saveFailed: 'Error al guardar el archivo .env global',
     },
     // Auto-update settings
+    autoPrune: {
+      title: 'Limpieza automática de imágenes',
+      description: 'Elimina automáticamente las imágenes Docker sin usar según una programación para liberar espacio en disco. Las imágenes en uso por un contenedor (incluido Lighthouse) nunca se eliminan.',
+      enableLabel: 'Activar la limpieza automática de imágenes',
+      danglingOnlyLabel: 'Solo imágenes huérfanas',
+      danglingOnlyHint: 'Desactivado: elimina toda imagen no usada por ningún contenedor.',
+      cronLabel: 'Programación (expresión cron)',
+    },
     autoUpdate: {
       composeTitle: 'Actualización automática',
       composeDescription: 'Actualiza automáticamente las imágenes y recrea los contenedores de los proyectos compose según una programación. Para excluir un proyecto, añada "x-auto-update: false" en la raíz de su archivo compose.',

--- a/lighthouse-front/src/lib/i18n/fr.ts
+++ b/lighthouse-front/src/lib/i18n/fr.ts
@@ -400,6 +400,14 @@ const fr = {
     checkInterval: 'Intervalle de vérification',
     intervalSaved: 'Intervalle de vérification enregistré',
     // Auto-update settings
+    autoPrune: {
+      title: 'Nettoyage automatique des images',
+      description: 'Supprime automatiquement les images Docker inutilisées selon un planning pour libérer de l’espace disque. Les images utilisées par un conteneur (y compris Lighthouse) ne sont jamais supprimées.',
+      enableLabel: 'Activer le nettoyage automatique des images',
+      danglingOnlyLabel: 'Images orphelines uniquement',
+      danglingOnlyHint: 'Désactivé : supprime toute image non utilisée par un conteneur.',
+      cronLabel: 'Planning (expression cron)',
+    },
     autoUpdate: {
       composeTitle: 'Mise à jour automatique',
       composeDescription: 'Met à jour automatiquement les images et recrée les conteneurs des projets compose selon une planification. Pour exclure un projet, ajoutez "x-auto-update: false" à la racine de son fichier compose.',

--- a/lighthouse-front/src/lib/stores/autoPrune.svelte.ts
+++ b/lighthouse-front/src/lib/stores/autoPrune.svelte.ts
@@ -1,0 +1,38 @@
+import { browser } from '$app/environment';
+import configApi from '$lib/api/config';
+import { logger } from '$lib/utils/logger';
+
+export const AUTO_PRUNE_KEYS = {
+  enabled: 'AutoPruneImagesEnabled',
+  cron: 'AutoPruneImagesCron',
+  danglingOnly: 'AutoPruneImagesDanglingOnly'
+} as const;
+
+const DEFAULT_CRON = '0 3 * * *';
+
+export const autoPruneState = $state({
+  enabled: false,
+  cron: DEFAULT_CRON,
+  danglingOnly: true,
+  loaded: false
+});
+
+function parseBool(value: string | undefined, fallback = false): boolean {
+  if (value === undefined) return fallback;
+  return value.toLowerCase() === 'true';
+}
+
+export async function loadAutoPruneSettings(): Promise<void> {
+  if (!browser) return;
+
+  try {
+    const settings = await configApi.getSettings();
+    autoPruneState.enabled = parseBool(settings[AUTO_PRUNE_KEYS.enabled]);
+    autoPruneState.cron = settings[AUTO_PRUNE_KEYS.cron] || DEFAULT_CRON;
+    // Absent setting defaults to dangling-only (safe), matching the backend.
+    autoPruneState.danglingOnly = parseBool(settings[AUTO_PRUNE_KEYS.danglingOnly], true);
+    autoPruneState.loaded = true;
+  } catch (error) {
+    logger.error('[Auto Prune Store] Failed to load settings:', error);
+  }
+}

--- a/lighthouse-front/src/routes/(protected)/settings/+page.svelte
+++ b/lighthouse-front/src/routes/(protected)/settings/+page.svelte
@@ -31,6 +31,11 @@
     AUTO_UPDATE_KEYS
   } from '$lib/stores/autoUpdate.svelte';
   import {
+    autoPruneState,
+    loadAutoPruneSettings,
+    AUTO_PRUNE_KEYS
+  } from '$lib/stores/autoPrune.svelte';
+  import {
     notificationsState,
     loadNotificationSettings,
     saveNotificationSetting,
@@ -201,6 +206,11 @@
   );
   let appCountdown = $derived(formatCountdown(appCronValidation.nextRun, countdownLabels, now));
 
+  let autoPruneCronValidation = $derived(validateCron(autoPruneState.cron, cronstrueLocale));
+  let autoPruneCountdown = $derived(
+    formatCountdown(autoPruneCronValidation.nextRun, countdownLabels, now)
+  );
+
   // Discord notification state
   // Webhook URL is write-only: the API returns it masked, so we only persist a
   // new value once the user actually edits the field.
@@ -267,6 +277,7 @@
 
   onMount(() => {
     void loadAutoUpdateSettings();
+    void loadAutoPruneSettings();
     void loadNotificationSettings();
     void loadGlobalEnvFile();
     void loadEnvPickerInitialPath();
@@ -320,6 +331,31 @@
   async function commitAppCron() {
     if (!appCronValidation.valid) return;
     await persistSetting(AUTO_UPDATE_KEYS.appCron, autoUpdateState.appCron.trim());
+  }
+
+  async function toggleAutoPruneEnabled(e: Event) {
+    const checked = (e.target as HTMLInputElement).checked;
+    const previous = autoPruneState.enabled;
+    autoPruneState.enabled = checked;
+    const ok = await persistSetting(AUTO_PRUNE_KEYS.enabled, checked ? 'true' : 'false');
+    if (!ok) autoPruneState.enabled = previous;
+  }
+
+  async function toggleAutoPruneDanglingOnly(e: Event) {
+    const checked = (e.target as HTMLInputElement).checked;
+    const previous = autoPruneState.danglingOnly;
+    autoPruneState.danglingOnly = checked;
+    const ok = await persistSetting(AUTO_PRUNE_KEYS.danglingOnly, checked ? 'true' : 'false');
+    if (!ok) autoPruneState.danglingOnly = previous;
+  }
+
+  function onAutoPruneCronInput(e: Event) {
+    autoPruneState.cron = (e.target as HTMLInputElement).value;
+  }
+
+  async function commitAutoPruneCron() {
+    if (!autoPruneCronValidation.valid) return;
+    await persistSetting(AUTO_PRUNE_KEYS.cron, autoPruneState.cron.trim());
   }
 
   async function persistNotificationSetting(key: string, value: string) {
@@ -780,6 +816,100 @@
                       — {$t('settings.autoUpdate.nextRun')}: {formatNextRun(composeCronValidation.nextRun)}
                       {#if composeCountdown}
                         <span class="text-gray-400 dark:text-gray-500">({$t('settings.autoUpdate.countdownIn')} {composeCountdown})</span>
+                      {/if}
+                    {/if}
+                  </p>
+                  <p class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">
+                    {$t('settings.autoUpdate.cronUtcHint')}
+                  </p>
+                {:else}
+                  <p class="text-xs text-red-600 dark:text-red-400 mt-1">
+                    {$t('settings.autoUpdate.cronInvalid')}
+                  </p>
+                {/if}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <!-- Auto Prune Images Card -->
+        <Card class="mt-6">
+          <CardHeader>
+            <CardTitle>{$t('settings.autoPrune.title')}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+              {$t('settings.autoPrune.description')}
+            </p>
+
+            <div class="space-y-4">
+              <label class="flex items-center gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={autoPruneState.enabled}
+                  onchange={toggleAutoPruneEnabled}
+                  disabled={savingKey === AUTO_PRUNE_KEYS.enabled}
+                  class="w-4 h-4 rounded border-gray-300 text-primary focus:ring-primary cursor-pointer"
+                />
+                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {$t('settings.autoPrune.enableLabel')}
+                </span>
+                {#if savingKey === AUTO_PRUNE_KEYS.enabled}
+                  <RefreshCw class="w-4 h-4 animate-spin text-gray-500" />
+                {/if}
+              </label>
+
+              <label class="flex items-center gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={autoPruneState.danglingOnly}
+                  onchange={toggleAutoPruneDanglingOnly}
+                  disabled={!autoPruneState.enabled || savingKey === AUTO_PRUNE_KEYS.danglingOnly}
+                  class="w-4 h-4 rounded border-gray-300 text-primary focus:ring-primary cursor-pointer disabled:opacity-50"
+                />
+                <span class="flex flex-col">
+                  <span class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {$t('settings.autoPrune.danglingOnlyLabel')}
+                  </span>
+                  <span class="text-xs text-gray-500 dark:text-gray-400">
+                    {$t('settings.autoPrune.danglingOnlyHint')}
+                  </span>
+                </span>
+                {#if savingKey === AUTO_PRUNE_KEYS.danglingOnly}
+                  <RefreshCw class="w-4 h-4 animate-spin text-gray-500" />
+                {/if}
+              </label>
+
+              <div class="flex flex-col gap-1">
+                <label for="auto-prune-cron" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {$t('settings.autoPrune.cronLabel')}
+                </label>
+                <div class="flex items-center gap-2">
+                  <input
+                    id="auto-prune-cron"
+                    type="text"
+                    value={autoPruneState.cron}
+                    oninput={onAutoPruneCronInput}
+                    onblur={commitAutoPruneCron}
+                    placeholder={$t('settings.autoUpdate.cronPlaceholder')}
+                    disabled={!autoPruneState.enabled || savingKey === AUTO_PRUNE_KEYS.cron}
+                    class="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white font-mono focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50"
+                  />
+                  {#if savingKey === AUTO_PRUNE_KEYS.cron}
+                    <RefreshCw class="w-4 h-4 animate-spin text-gray-500" />
+                  {:else if autoPruneCronValidation.valid}
+                    <Check class="w-4 h-4 text-green-600 dark:text-green-400" />
+                  {:else}
+                    <X class="w-4 h-4 text-red-600 dark:text-red-400" />
+                  {/if}
+                </div>
+                {#if autoPruneCronValidation.valid}
+                  <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    {autoPruneCronValidation.humanReadable ?? ''}
+                    {#if autoPruneCronValidation.nextRun}
+                      — {$t('settings.autoUpdate.nextRun')}: {formatNextRun(autoPruneCronValidation.nextRun)}
+                      {#if autoPruneCountdown}
+                        <span class="text-gray-400 dark:text-gray-500">({$t('settings.autoUpdate.countdownIn')} {autoPruneCountdown})</span>
                       {/if}
                     {/if}
                   </p>


### PR DESCRIPTION
Final piece of GitHub issue #82 (Docker image management): an opt-in background service that prunes unused images on a schedule, plus a settings card to configure it. Builds on the PR1 API (#162) and PR2 UI (#163).

## What's included

**Background service** (`AutoPruneImagesBackgroundService`)
- Cron-driven (default `0 3 * * *`), **disabled by default**. Reuses `ImageService.PruneImagesAsync`.
- Prunes **dangling images only** by default; a setting switches to all-unused.
- Skips a cycle while a self-update is in progress (the new image may not yet be referenced by a container).
- Audit-logs each run and broadcasts the `ImagesChanged` SSE event when anything is removed (so open `/images` tabs refresh live).
- Modelled on `AutoUpdateComposeBackgroundService` (cron tick loop + `AppSettings`).

**Settings**
- `AppSettings` keys: `AutoPruneImagesEnabled`, `AutoPruneImagesCron`, `AutoPruneImagesDanglingOnly`, validated in `ConfigController`.

**Settings UI**
- An "Auto Prune Images" card (enable toggle, cron input with validation / next-run / countdown, dangling-only toggle), mirroring the auto-update cards, backed by a new `autoPrune` store. i18n in **en / fr / es**.

## Notes

- Scope decision: default **dangling-only** (safe) with a toggle for all-unused, matching the choice made for the manual prune in PR2.
- The scheduling loop follows the existing (untested) background-service convention; the actual prune is covered by `ImageServiceTests` (PruneImagesAsync).

## Verification

- Backend `dotnet build -c Release` clean; full suite (351) passes.
- Frontend `npm run check` 0 errors; `npm run build` succeeds.

This completes issue #82 except the deferred optional "prune before up during update" (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)