### PR TITLE
ci: scheduled GitHub Actions cache cleanup

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,17 @@
+name: Cache Cleanup
+
+on:
+  schedule:
+    - cron: '0 3 * * *' # daily at 03:00 UTC
+  workflow_dispatch: # allow manual trigger
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cache-cleanup:
+    uses: JordanOlivet/ci-workflows/.github/workflows/cache-cleanup.yml@v1
+    with:
+      threshold-gb: 9
+    secrets: inherit


### PR DESCRIPTION
## Problem

Docker builds export BuildKit cache with `mode=max`, which grows past the 10 GB repo cache limit. The v1.26.0 release pipeline (run 28549598112) failed at the cache export step with `failed to reserve cache`, skipping `create-gh-release`.

## Changes

Add a scheduled workflow (daily 03:00 UTC + manual `workflow_dispatch`) calling the new `cache-cleanup` reusable from ci-workflows ([JordanOlivet/ci-workflows#6](https://github.com/JordanOlivet/ci-workflows/pull/6)). It prunes the oldest caches when repo cache usage exceeds 9 GB, and is a no-op otherwise.

Combined with `ignore-error=true` now set on the docker build cache export (same ci-workflows PR), cache issues can no longer break releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)