### PR TITLE
fix(security): critical/high fixes from full app review

### DIFF
--- a/lighthouse-back/lighthouse-back.Tests/Services/PathValidatorTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/PathValidatorTests.cs
@@ -310,4 +310,30 @@ public class PathValidatorTests : IDisposable
         // Assert
         result.Should().BeTrue();
     }
+
+    [Fact]
+    public void IsValidComposeFilePath_SiblingDirectorySharingRootPrefix_ReturnsFalse()
+    {
+        // Arrange - A sibling directory whose name starts with the root path string
+        // (e.g. root "/app/compose-files" vs "/app/compose-files-evil"). A naive
+        // StartsWith check without a trailing separator would wrongly accept this.
+        var siblingPath = _testRoot + "-evil" + Path.DirectorySeparatorChar + "docker-compose.yml";
+
+        // Act
+        var result = _validator.IsValidComposeFilePath(siblingPath);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidComposeFilePath_RootItself_ReturnsTrue()
+    {
+        // Arrange - The root path itself (no trailing separator) must remain valid.
+        // Act
+        var result = _validator.IsValidComposeFilePath(_testRoot);
+
+        // Assert
+        result.Should().BeTrue();
+    }
 }

--- a/lighthouse-back/lighthouse-back/Program.cs
+++ b/lighthouse-back/lighthouse-back/Program.cs
@@ -416,7 +416,10 @@ app.MapGet("/health/detailed", async (AppDbContext dbContext, DockerService dock
 })
    .WithName("HealthCheckDetailed")
    .WithTags("Health")
-   .AllowAnonymous();
+   // Detailed health exposes user/container counts and raw dependency error messages,
+   // so it must not be anonymous. The simple /health endpoint stays public for the
+   // Docker container healthcheck.
+   .RequireAuthorization(new Microsoft.AspNetCore.Authorization.AuthorizeAttribute { Roles = "admin" });
 
 app.MapControllers();
 

--- a/lighthouse-back/lighthouse-back/src/Controllers/AuditController.cs
+++ b/lighthouse-back/lighthouse-back/src/Controllers/AuditController.cs
@@ -9,7 +9,7 @@ namespace Lighthouse.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-[Authorize]
+[Authorize(Roles = "admin")]
 public class AuditController : BaseController
 {
     private readonly IAuditService _auditService;

--- a/lighthouse-back/lighthouse-back/src/Controllers/AuthController.cs
+++ b/lighthouse-back/lighthouse-back/src/Controllers/AuthController.cs
@@ -7,6 +7,7 @@ using Lighthouse.DTOs;
 using Lighthouse.Services;
 using Lighthouse.Middleware;
 using Lighthouse.Data;
+using Lighthouse.Extensions;
 
 namespace Lighthouse.Controllers;
 
@@ -41,7 +42,7 @@ public class AuthController : BaseController
 
         _logger.LogInformation("Login attempt for user {Username} from {IpAddress}", request.Username, ipAddress);
 
-        var (success, response, error) = await _authService.LoginAsync(request, ipAddress, userAgent);
+        var (success, response, refreshExpiresAt, error) = await _authService.LoginAsync(request, ipAddress, userAgent);
 
         if (!success)
         {
@@ -49,44 +50,63 @@ public class AuthController : BaseController
             return Unauthorized(ApiResponse.Fail<LoginResponse>(error ?? "Invalid credentials", "AUTH_INVALID_CREDENTIALS"));
         }
 
+        // Deliver the refresh token exclusively via the HttpOnly cookie; never expose it
+        // to JavaScript in the response body.
+        Response.SetRefreshCookie(response!.RefreshToken, refreshExpiresAt!.Value, Request.IsHttps);
+
         _logger.LogInformation("User {Username} logged in successfully", request.Username);
-        return Ok(ApiResponse.Ok(response, "Login successful"));
+        return Ok(ApiResponse.Ok(response with { RefreshToken = string.Empty }, "Login successful"));
     }
 
     [HttpPost("refresh")]
     [AllowAnonymous]
     [EnableRateLimiting(RateLimitingConfiguration.RefreshPolicy)]
-    public async Task<ActionResult<ApiResponse<LoginResponse>>> RefreshToken([FromBody] RefreshTokenRequest request)
+    public async Task<ActionResult<ApiResponse<LoginResponse>>> RefreshToken([FromBody] RefreshTokenRequest? request = null)
     {
         var ipAddress = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
 
-        var (success, response, error) = await _authService.RefreshTokenAsync(request.RefreshToken, ipAddress);
+        var refreshToken = Request.GetRefreshToken(request?.RefreshToken);
+        if (string.IsNullOrEmpty(refreshToken))
+        {
+            Response.ClearRefreshCookie(Request.IsHttps);
+            return Unauthorized(ApiResponse.Fail<LoginResponse>("Invalid refresh token", "AUTH_TOKEN_INVALID"));
+        }
+
+        var (success, response, refreshExpiresAt, error) = await _authService.RefreshTokenAsync(refreshToken, ipAddress);
 
         if (!success)
         {
+            Response.ClearRefreshCookie(Request.IsHttps);
             return Unauthorized(ApiResponse.Fail<LoginResponse>(error ?? "Invalid refresh token", "AUTH_TOKEN_INVALID"));
         }
 
-        return Ok(ApiResponse.Ok(response, "Token refreshed successfully"));
+        // Rotate the refresh cookie; keep the token out of the response body.
+        Response.SetRefreshCookie(response!.RefreshToken, refreshExpiresAt!.Value, Request.IsHttps);
+
+        return Ok(ApiResponse.Ok(response with { RefreshToken = string.Empty }, "Token refreshed successfully"));
     }
 
     [HttpPost("logout")]
     [Authorize]
-    public async Task<ActionResult<ApiResponse<bool>>> Logout([FromBody] RefreshTokenRequest request)
+    public async Task<ActionResult<ApiResponse<bool>>> Logout([FromBody] RefreshTokenRequest? request = null)
     {
         var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         _logger.LogInformation("User {UserId} logging out", userId);
 
-        var success = await _authService.LogoutAsync(request.RefreshToken);
-
-        if (!success)
+        var refreshToken = Request.GetRefreshToken(request?.RefreshToken);
+        if (!string.IsNullOrEmpty(refreshToken))
         {
-            // Log the issue but still return success - logout is idempotent
-            // If the session doesn't exist, the user is effectively logged out already
-            _logger.LogWarning("User {UserId} attempted to logout with invalid or expired refresh token", userId);
+            var success = await _authService.LogoutAsync(refreshToken);
+            if (!success)
+            {
+                // Log the issue but still return success - logout is idempotent
+                // If the session doesn't exist, the user is effectively logged out already
+                _logger.LogWarning("User {UserId} attempted to logout with invalid or expired refresh token", userId);
+            }
         }
 
-        // Always return success to make logout idempotent
+        // Always clear the cookie and return success to make logout idempotent
+        Response.ClearRefreshCookie(Request.IsHttps);
         return Ok(ApiResponse.Ok(true, "Logged out successfully"));
     }
 
@@ -113,7 +133,7 @@ public class AuthController : BaseController
 
         _logger.LogInformation("User {UserId} attempting to change password", userId);
 
-        var (success, accessToken, refreshToken) = await _authService.ChangePasswordAsync(userId, request.CurrentPassword, request.NewPassword, ipAddress, userAgent);
+        var (success, accessToken, refreshToken, refreshExpiresAt) = await _authService.ChangePasswordAsync(userId, request.CurrentPassword, request.NewPassword, ipAddress, userAgent);
 
         if (!success)
         {
@@ -125,9 +145,13 @@ public class AuthController : BaseController
             .Include(u => u.Role)
             .FirstOrDefaultAsync(u => u.Id == userId);
 
+        // Password change rotates the session: deliver the new refresh token via the
+        // HttpOnly cookie only, never in the response body.
+        Response.SetRefreshCookie(refreshToken!, refreshExpiresAt!.Value, Request.IsHttps);
+
         var response = new LoginResponse(
             AccessToken: accessToken!,
-            RefreshToken: refreshToken!,
+            RefreshToken: string.Empty,
             Username: user!.Username,
             Role: user.Role!.Name,
             MustChangePassword: user.MustChangePassword,

--- a/lighthouse-back/lighthouse-back/src/Controllers/ComposeFilesController.cs
+++ b/lighthouse-back/lighthouse-back/src/Controllers/ComposeFilesController.cs
@@ -123,10 +123,11 @@ public class ComposeFilesController : BaseController
     /// - "degraded": Compose discovery unavailable but Docker accessible (can still manage existing projects)
     /// - "critical": Docker daemon inaccessible (system non-functional)
     ///
-    /// No authentication required - this is a diagnostic endpoint.
+    /// Requires authentication: this endpoint discloses the Docker daemon version and
+    /// raw connection error messages, so it must not be reachable anonymously. The
+    /// frontend only calls it from the authenticated layout.
     /// </remarks>
     [HttpGet("health")]
-    [AllowAnonymous]
     public async Task<ActionResult<ApiResponse<ComposeHealthDto>>> GetHealth()
     {
         // Check compose discovery directory

--- a/lighthouse-back/lighthouse-back/src/Controllers/ProfileController.cs
+++ b/lighthouse-back/lighthouse-back/src/Controllers/ProfileController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Lighthouse.DTOs;
+using Lighthouse.Extensions;
 using Lighthouse.Services;
 using System.Security.Claims;
 
@@ -146,7 +147,7 @@ public class ProfileController : BaseController
 
             // Password complexity is validated by ChangePasswordRequestValidator (FluentValidation)
 
-            var (success, accessToken, refreshToken) = await _authService.ChangePasswordAsync(userId, request.CurrentPassword, request.NewPassword, ipAddress, userAgent);
+            var (success, accessToken, refreshToken, refreshExpiresAt) = await _authService.ChangePasswordAsync(userId, request.CurrentPassword, request.NewPassword, ipAddress, userAgent);
 
             if (!success)
             {
@@ -165,9 +166,12 @@ public class ProfileController : BaseController
             // Get updated user info
             var user = await _userService.GetUserByIdAsync(userId);
 
+            // Rotate the refresh token via the HttpOnly cookie only, never in the body.
+            Response.SetRefreshCookie(refreshToken!, refreshExpiresAt!.Value, Request.IsHttps);
+
             var response = new LoginResponse(
                 AccessToken: accessToken!,
-                RefreshToken: refreshToken!,
+                RefreshToken: string.Empty,
                 Username: user!.Username,
                 Role: user.Role,
                 MustChangePassword: user.MustChangePassword,

--- a/lighthouse-back/lighthouse-back/src/DTOs/AuthDtos.cs
+++ b/lighthouse-back/lighthouse-back/src/DTOs/AuthDtos.cs
@@ -11,7 +11,9 @@ public record LoginResponse(
     bool MustAddEmail
 );
 
-public record RefreshTokenRequest(string RefreshToken);
+// RefreshToken is optional: browsers send it via the HttpOnly `lh_refresh` cookie.
+// The body field is kept for non-browser clients / backward compatibility.
+public record RefreshTokenRequest(string? RefreshToken = null);
 
 public record ChangePasswordRequest(string CurrentPassword, string NewPassword);
 

--- a/lighthouse-back/lighthouse-back/src/Extensions/RefreshCookieExtensions.cs
+++ b/lighthouse-back/lighthouse-back/src/Extensions/RefreshCookieExtensions.cs
@@ -1,0 +1,49 @@
+namespace Lighthouse.Extensions;
+
+/// <summary>
+/// Helpers for the HttpOnly refresh-token cookie.
+/// The refresh token is delivered exclusively via this cookie so it is never
+/// readable by JavaScript (defense against token theft through XSS). The path is
+/// scoped to /api/auth so the browser only sends it to the refresh/logout endpoints.
+/// </summary>
+public static class RefreshCookieExtensions
+{
+    public const string RefreshCookieName = "lh_refresh";
+    private const string RefreshCookiePath = "/api/auth";
+
+    public static void SetRefreshCookie(this HttpResponse response, string refreshToken, DateTime expiresAt, bool isHttps)
+    {
+        response.Cookies.Append(RefreshCookieName, refreshToken, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = isHttps,
+            SameSite = SameSiteMode.Lax,
+            Path = RefreshCookiePath,
+            Expires = new DateTimeOffset(expiresAt, TimeSpan.Zero),
+            IsEssential = true
+        });
+    }
+
+    public static void ClearRefreshCookie(this HttpResponse response, bool isHttps)
+    {
+        response.Cookies.Delete(RefreshCookieName, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = isHttps,
+            SameSite = SameSiteMode.Lax,
+            Path = RefreshCookiePath,
+            IsEssential = true
+        });
+    }
+
+    /// <summary>
+    /// Reads the refresh token from the HttpOnly cookie, falling back to the provided
+    /// body value (for non-browser clients / backward compatibility).
+    /// </summary>
+    public static string? GetRefreshToken(this HttpRequest request, string? bodyValue)
+    {
+        if (request.Cookies.TryGetValue(RefreshCookieName, out var cookieToken) && !string.IsNullOrEmpty(cookieToken))
+            return cookieToken;
+        return bodyValue;
+    }
+}

--- a/lighthouse-back/lighthouse-back/src/Middleware/RateLimitingConfiguration.cs
+++ b/lighthouse-back/lighthouse-back/src/Middleware/RateLimitingConfiguration.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.RateLimiting;
+using System.Security.Claims;
 using System.Threading.RateLimiting;
 
 namespace Lighthouse.Middleware;
@@ -15,50 +16,65 @@ public static class RateLimitingConfiguration
     {
         services.AddRateLimiter(options =>
         {
-            // Auth endpoints: 20 attempts per 15 minutes per IP
-            options.AddFixedWindowLimiter(AuthPolicy, limiterOptions =>
-            {
-                limiterOptions.PermitLimit = 20;
-                limiterOptions.Window = TimeSpan.FromMinutes(15);
-                limiterOptions.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
-                limiterOptions.QueueLimit = 0; // No queueing
-            });
+            // Auth endpoints: 20 attempts per 15 minutes per client IP
+            options.AddPolicy(AuthPolicy, httpContext =>
+                RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: GetClientIp(httpContext),
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = 20,
+                        Window = TimeSpan.FromMinutes(15),
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 0
+                    }));
 
-            // Refresh token endpoint: 20 attempts per 15 minutes per IP
-            options.AddFixedWindowLimiter(RefreshPolicy, limiterOptions =>
-            {
-                limiterOptions.PermitLimit = 20;
-                limiterOptions.Window = TimeSpan.FromMinutes(15);
-                limiterOptions.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
-                limiterOptions.QueueLimit = 0; // No queueing
-            });
+            // Refresh token endpoint: 20 attempts per 15 minutes per client IP
+            options.AddPolicy(RefreshPolicy, httpContext =>
+                RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: GetClientIp(httpContext),
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = 20,
+                        Window = TimeSpan.FromMinutes(15),
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 0
+                    }));
 
-            // General API: 100 requests per minute per user
-            options.AddFixedWindowLimiter(GeneralApiPolicy, limiterOptions =>
-            {
-                limiterOptions.PermitLimit = 100;
-                limiterOptions.Window = TimeSpan.FromMinutes(1);
-                limiterOptions.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
-                limiterOptions.QueueLimit = 10;
-            });
+            // General API: 100 requests per minute per authenticated user (falls back to IP)
+            options.AddPolicy(GeneralApiPolicy, httpContext =>
+                RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: GetUserOrIpKey(httpContext),
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = 100,
+                        Window = TimeSpan.FromMinutes(1),
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 10
+                    }));
 
-            // Forgot password: 3 attempts per hour per IP
-            options.AddFixedWindowLimiter(ForgotPasswordPolicy, limiterOptions =>
-            {
-                limiterOptions.PermitLimit = 5;
-                limiterOptions.Window = TimeSpan.FromHours(1);
-                limiterOptions.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
-                limiterOptions.QueueLimit = 0; // No queueing
-            });
+            // Forgot password: 5 attempts per hour per client IP
+            options.AddPolicy(ForgotPasswordPolicy, httpContext =>
+                RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: GetClientIp(httpContext),
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = 5,
+                        Window = TimeSpan.FromHours(1),
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 0
+                    }));
 
-            // Reset password: 5 attempts per hour per IP
-            options.AddFixedWindowLimiter(ResetPasswordPolicy, limiterOptions =>
-            {
-                limiterOptions.PermitLimit = 5;
-                limiterOptions.Window = TimeSpan.FromHours(1);
-                limiterOptions.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
-                limiterOptions.QueueLimit = 0; // No queueing
-            });
+            // Reset password: 5 attempts per hour per client IP
+            options.AddPolicy(ResetPasswordPolicy, httpContext =>
+                RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: GetClientIp(httpContext),
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = 5,
+                        Window = TimeSpan.FromHours(1),
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 0
+                    }));
 
             // Global rejection response
             options.OnRejected = async (context, token) =>
@@ -81,5 +97,37 @@ public static class RateLimitingConfiguration
                 }, cancellationToken: token);
             };
         });
+    }
+
+    /// <summary>
+    /// Resolves the real client IP. Behind the bundled nginx reverse proxy the socket
+    /// remote address is always the proxy (127.0.0.1), so the forwarded headers set by
+    /// nginx (X-Forwarded-For / X-Real-IP) must be used to partition per real client.
+    /// </summary>
+    private static string GetClientIp(HttpContext httpContext)
+    {
+        string? forwardedFor = httpContext.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+        if (!string.IsNullOrWhiteSpace(forwardedFor))
+        {
+            // X-Forwarded-For may be a comma-separated chain: the first entry is the origin client.
+            string first = forwardedFor.Split(',')[0].Trim();
+            if (!string.IsNullOrEmpty(first))
+                return first;
+        }
+
+        string? realIp = httpContext.Request.Headers["X-Real-IP"].FirstOrDefault();
+        if (!string.IsNullOrWhiteSpace(realIp))
+            return realIp.Trim();
+
+        return httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+    }
+
+    /// <summary>
+    /// Partition key for authenticated endpoints: the user id when present, otherwise the client IP.
+    /// </summary>
+    private static string GetUserOrIpKey(HttpContext httpContext)
+    {
+        string? userId = httpContext.User?.FindFirstValue(ClaimTypes.NameIdentifier);
+        return !string.IsNullOrEmpty(userId) ? $"user:{userId}" : $"ip:{GetClientIp(httpContext)}";
     }
 }

--- a/lighthouse-back/lighthouse-back/src/Services/AuthService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/AuthService.cs
@@ -25,7 +25,7 @@ public class AuthService
         _passwordHasher = passwordHasher;
     }
 
-    public async Task<(bool Success, LoginResponse? Response, string? Error)> LoginAsync(LoginRequest request, string ipAddress, string deviceInfo)
+    public async Task<(bool Success, LoginResponse? Response, DateTime? RefreshExpiresAt, string? Error)> LoginAsync(LoginRequest request, string ipAddress, string deviceInfo)
     {
         var user = await _context.Users
             .Include(u => u.Role)
@@ -33,12 +33,12 @@ public class AuthService
 
         if (user == null || !user.IsEnabled)
         {
-            return (false, null, "Invalid credentials");
+            return (false, null, null, "Invalid credentials");
         }
 
         if (!_passwordHasher.VerifyPassword(request.Password, user.PasswordHash))
         {
-            return (false, null, "Invalid credentials");
+            return (false, null, null, "Invalid credentials");
         }
 
         // Generate tokens
@@ -79,10 +79,10 @@ public class AuthService
             user.MustAddEmail
         );
 
-        return (true, response, null);
+        return (true, response, expiresAt, null);
     }
 
-    public async Task<(bool Success, LoginResponse? Response, string? Error)> RefreshTokenAsync(string refreshToken, string ipAddress)
+    public async Task<(bool Success, LoginResponse? Response, DateTime? RefreshExpiresAt, string? Error)> RefreshTokenAsync(string refreshToken, string ipAddress)
     {
         var session = await _context.Sessions
             .Include(s => s.User)
@@ -91,7 +91,7 @@ public class AuthService
 
         if (session == null || session.ExpiresAt < DateTime.UtcNow || !session.User.IsEnabled)
         {
-            return (false, null, "Invalid or expired refresh token");
+            return (false, null, null, "Invalid or expired refresh token");
         }
 
         // Update session
@@ -115,7 +115,8 @@ public class AuthService
             session.User.MustAddEmail
         );
 
-        return (true, response, null);
+        // Refresh token rotation keeps the original session expiry (no sliding window here).
+        return (true, response, session.ExpiresAt, null);
     }
 
     public async Task<bool> LogoutAsync(string refreshToken)
@@ -132,7 +133,7 @@ public class AuthService
         return false;
     }
 
-    public async Task<(bool Success, string? AccessToken, string? RefreshToken)> ChangePasswordAsync(int userId, string currentPassword, string newPassword, string ipAddress, string userAgent)
+    public async Task<(bool Success, string? AccessToken, string? RefreshToken, DateTime? RefreshExpiresAt)> ChangePasswordAsync(int userId, string currentPassword, string newPassword, string ipAddress, string userAgent)
     {
         var user = await _context.Users
             .Include(u => u.Role)
@@ -140,7 +141,7 @@ public class AuthService
 
         if (user == null || !_passwordHasher.VerifyPassword(currentPassword, user.PasswordHash))
         {
-            return (false, null, null);
+            return (false, null, null, null);
         }
 
         user.PasswordHash = _passwordHasher.HashPassword(newPassword);
@@ -154,12 +155,14 @@ public class AuthService
         // Create a new session with new tokens
         var accessToken = _jwtService.GenerateAccessToken(user);
         var refreshToken = _jwtService.GenerateRefreshToken();
+        var expiresAt = DateTime.UtcNow.AddDays(
+            int.Parse(_configuration["Jwt:RefreshExpirationDays"] ?? "1"));
 
         var newSession = new Session
         {
             UserId = user.Id,
             RefreshToken = refreshToken,
-            ExpiresAt = DateTime.UtcNow.AddDays(7),
+            ExpiresAt = expiresAt,
             IpAddress = ipAddress,
             DeviceInfo = userAgent,
             CreatedAt = DateTime.UtcNow
@@ -168,7 +171,7 @@ public class AuthService
         _context.Sessions.Add(newSession);
         await _context.SaveChangesAsync();
 
-        return (true, accessToken, refreshToken);
+        return (true, accessToken, refreshToken, expiresAt);
     }
 
     public async Task<bool> AddEmailAsync(int userId, string email)

--- a/lighthouse-back/lighthouse-back/src/Services/PathValidatorService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/PathValidatorService.cs
@@ -60,16 +60,25 @@ public class PathValidatorService : IPathValidator
 
         try
         {
-            // Get the absolute path of the configured root directory
+            // Get the absolute path of the configured root directory, normalized with a
+            // trailing separator so prefix comparison cannot be defeated by a sibling
+            // directory sharing the root's name (e.g. "/app/compose-files-evil" must NOT
+            // match root "/app/compose-files").
             var rootPath = Path.GetFullPath(_options.RootPath);
+            var rootWithSeparator = rootPath.EndsWith(Path.DirectorySeparatorChar)
+                ? rootPath
+                : rootPath + Path.DirectorySeparatorChar;
 
             // Get the absolute path of the user-provided path
             // This resolves any relative path segments (like ../)
             var fullPath = Path.GetFullPath(userProvidedPath);
 
-            // Check if the resolved path is within the root directory
-            // This prevents path traversal attacks
-            if (!fullPath.StartsWith(rootPath, StringComparison.OrdinalIgnoreCase))
+            // Check if the resolved path is within the root directory.
+            // Accept the root itself, and anything strictly under root/ (with separator).
+            bool isRootItself = string.Equals(fullPath, rootPath, StringComparison.OrdinalIgnoreCase);
+            bool isUnderRoot = fullPath.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase);
+
+            if (!isRootItself && !isUnderRoot)
             {
                 _logger.LogWarning(
                     "Path traversal attempt detected. Path: {Path}, Root: {Root}",

--- a/lighthouse-back/lighthouse-back/src/Validators/AuthValidators.cs
+++ b/lighthouse-back/lighthouse-back/src/Validators/AuthValidators.cs
@@ -33,9 +33,12 @@ public class RefreshTokenRequestValidator : AbstractValidator<RefreshTokenReques
 {
     public RefreshTokenRequestValidator()
     {
+        // The refresh token is normally carried by the HttpOnly `lh_refresh` cookie, so the
+        // body value is optional. When a non-browser client does supply it in the body,
+        // enforce a minimum length; the controller rejects a genuinely missing token.
         RuleFor(x => x.RefreshToken)
-            .NotEmpty().WithMessage("Refresh token is required")
-            .MinimumLength(20).WithMessage("Invalid refresh token format");
+            .MinimumLength(20).WithMessage("Invalid refresh token format")
+            .When(x => !string.IsNullOrEmpty(x.RefreshToken));
     }
 }
 

--- a/lighthouse-front/src/lib/api/auth.ts
+++ b/lighthouse-front/src/lib/api/auth.ts
@@ -7,8 +7,9 @@ export const login = async (credentials: LoginRequest): Promise<LoginResponse> =
   return response.data.data!;
 };
 
-export const logout = async (refreshToken: string): Promise<void> => {
-  await apiClient.post('/auth/logout', { refreshToken });
+export const logout = async (): Promise<void> => {
+  // The refresh token is sent via the HttpOnly cookie (withCredentials).
+  await apiClient.post('/auth/logout');
 };
 
 export const getCurrentUser = async (): Promise<User> => {

--- a/lighthouse-front/src/lib/api/client.ts
+++ b/lighthouse-front/src/lib/api/client.ts
@@ -53,24 +53,18 @@ async function proactiveTokenRefresh(): Promise<boolean> {
     return true; // Token is still valid, no refresh needed
   }
 
-  const refreshToken = localStorage.getItem('refreshToken');
-  if (!refreshToken) {
-    auth.logout();
-    window.location.href = '/login';
-    return false;
-  }
-
   try {
+    // The refresh token is sent automatically via the HttpOnly `lh_refresh` cookie
+    // (withCredentials), so no token is read from or written to JavaScript storage.
     const refreshUrl = API_URL ? `${API_URL}/api/auth/refresh` : '/api/auth/refresh';
-    const response = await axios.post(refreshUrl, { refreshToken });
+    const response = await axios.post(refreshUrl, {}, { withCredentials: true });
 
-    const { accessToken, refreshToken: newRefreshToken } = response.data.data;
+    const { accessToken } = response.data.data;
 
     localStorage.setItem('accessToken', accessToken);
-    localStorage.setItem('refreshToken', newRefreshToken);
 
     // Synchronize with Svelte store
-    auth.refreshTokens(accessToken, newRefreshToken);
+    auth.refreshTokens(accessToken);
 
     // Reconnect SSE with the new token
     reconnectSSEWithNewToken();
@@ -103,6 +97,8 @@ export const apiClient = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  // Send the HttpOnly refresh-token cookie on auth requests (login/refresh/logout).
+  withCredentials: true,
 });
 
 // Request interceptor to add auth token
@@ -143,23 +139,16 @@ apiClient.interceptors.response.use(
       }
 
       try {
-        const refreshToken = localStorage.getItem('refreshToken');
-        if (!refreshToken) {
-          throw new Error('No refresh token available');
-        }
-
+        // Refresh via the HttpOnly cookie (withCredentials); no token in JS storage.
         const refreshUrl = API_URL ? `${API_URL}/api/auth/refresh` : '/api/auth/refresh';
-        const response = await axios.post(refreshUrl, {
-          refreshToken,
-        });
+        const response = await axios.post(refreshUrl, {}, { withCredentials: true });
 
-        const { accessToken, refreshToken: newRefreshToken } = response.data.data;
+        const { accessToken } = response.data.data;
 
         localStorage.setItem('accessToken', accessToken);
-        localStorage.setItem('refreshToken', newRefreshToken);
 
         // Synchronise le store Svelte après refresh
-        auth.refreshTokens(accessToken, newRefreshToken);
+        auth.refreshTokens(accessToken);
 
         // Reconnect SSE with the new token
         reconnectSSEWithNewToken();

--- a/lighthouse-front/src/lib/components/UserFormDialog.svelte
+++ b/lighthouse-front/src/lib/components/UserFormDialog.svelte
@@ -287,7 +287,7 @@
 
 				{#if error}
 					<div class="mb-4 p-3 bg-red-100 dark:bg-red-900/30 border border-red-400 dark:border-red-700 text-red-700 dark:text-red-300 rounded-lg text-sm whitespace-pre-line">
-					{@html error}
+					{error}
 					</div>
 				{/if}
 

--- a/lighthouse-front/src/lib/components/layout/UserMenu.svelte
+++ b/lighthouse-front/src/lib/components/layout/UserMenu.svelte
@@ -28,10 +28,9 @@
   async function handleLogout() {
     isOpen = false;
     try {
-      const refreshToken = localStorage.getItem('refreshToken');
-      if (refreshToken) {
-        await authApi.logout(refreshToken);
-      }
+      // The refresh token is sent via the HttpOnly cookie; the backend revokes the
+      // session and clears the cookie.
+      await authApi.logout();
     } catch (error) {
       logger.error('Logout error:', error);
     } finally {

--- a/lighthouse-front/src/lib/stores/auth.svelte.ts
+++ b/lighthouse-front/src/lib/stores/auth.svelte.ts
@@ -2,10 +2,13 @@ import { browser } from '$app/environment';
 import type { User } from '$lib/types';
 
 // Svelte 5 pattern: export state object with properties (not individual $state variables)
+//
+// Only the short-lived access token is held client-side. The refresh token lives
+// exclusively in an HttpOnly cookie (`lh_refresh`) set by the backend and is never
+// readable by JavaScript — this is the defense against token theft via XSS.
 export const auth = $state({
   user: null as User | null,
-  accessToken: browser ? localStorage.getItem('accessToken') : null,
-  refreshToken: browser ? localStorage.getItem('refreshToken') : null
+  accessToken: browser ? localStorage.getItem('accessToken') : null
 });
 
 // Derived state as getters - Svelte 5 doesn't allow exporting $derived
@@ -17,35 +20,31 @@ export const isAdmin = {
 };
 
 // Actions
-export function login(newAccessToken: string, newRefreshToken: string, newUser: User) {
+export function login(newAccessToken: string, newUser: User) {
   if (browser) {
     localStorage.setItem('accessToken', newAccessToken);
-    localStorage.setItem('refreshToken', newRefreshToken);
   }
   auth.user = newUser;
   auth.accessToken = newAccessToken;
-  auth.refreshToken = newRefreshToken;
 }
 
 export function logout() {
   if (browser) {
     localStorage.removeItem('accessToken');
+    // Clean up any legacy refresh token left over from a previous version.
     localStorage.removeItem('refreshToken');
   }
   auth.user = null;
   auth.accessToken = null;
-  auth.refreshToken = null;
 }
 
 export function updateUser(newUser: User) {
   auth.user = newUser;
 }
 
-export function refreshTokens(newAccessToken: string, newRefreshToken: string) {
+export function refreshTokens(newAccessToken: string) {
   if (browser) {
     localStorage.setItem('accessToken', newAccessToken);
-    localStorage.setItem('refreshToken', newRefreshToken);
   }
   auth.accessToken = newAccessToken;
-  auth.refreshToken = newRefreshToken;
 }

--- a/lighthouse-front/src/lib/stores/sse.svelte.ts
+++ b/lighthouse-front/src/lib/stores/sse.svelte.ts
@@ -107,31 +107,26 @@ async function ensureFreshToken(): Promise<string | null> {
 
   logger.log('[SSE Store] Token expired or missing, attempting refresh');
 
-  const refreshToken = localStorage.getItem('refreshToken');
-  if (!refreshToken) {
-    logger.warn('[SSE Store] No refresh token available');
-    return null;
-  }
-
   try {
     const apiUrl = getApiUrl();
     const refreshUrl = apiUrl
       ? `${apiUrl}/api/auth/refresh`
       : '/api/auth/refresh';
 
+    // The refresh token is sent via the HttpOnly `lh_refresh` cookie (credentials: 'include').
     const response = await fetch(refreshUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ refreshToken }),
+      credentials: 'include',
+      body: '{}',
     });
 
     if (response.ok) {
       const data = await response.json();
-      const { accessToken, refreshToken: newRefreshToken } = data.data;
+      const { accessToken } = data.data;
 
       localStorage.setItem('accessToken', accessToken);
-      localStorage.setItem('refreshToken', newRefreshToken);
-      updateAuthTokens(accessToken, newRefreshToken);
+      updateAuthTokens(accessToken);
 
       logger.log('[SSE Store] Token refreshed successfully');
       return accessToken;

--- a/lighthouse-front/src/lib/types/index.ts
+++ b/lighthouse-front/src/lib/types/index.ts
@@ -31,7 +31,8 @@ export interface LoginRequest {
 
 export interface LoginResponse {
   accessToken: string;
-  refreshToken: string;
+  /** Deprecated: the refresh token now lives in an HttpOnly cookie and is returned empty. */
+  refreshToken?: string;
   username: string;
   role: string;
   mustChangePassword: boolean;

--- a/lighthouse-front/src/routes/change-password/+page.svelte
+++ b/lighthouse-front/src/routes/change-password/+page.svelte
@@ -41,17 +41,17 @@
       const response = await authApi.changePassword(currentPassword, newPassword);
       toast.success($t('auth.passwordChanged'));
 
-      // Update tokens in localStorage
+      // Store the new access token only; the rotated refresh token is set as an
+      // HttpOnly cookie by the backend.
       if (typeof localStorage !== 'undefined') {
         localStorage.setItem('accessToken', response.accessToken);
-        localStorage.setItem('refreshToken', response.refreshToken);
       }
 
       // Fetch updated user data
       const user = await authApi.getCurrentUser();
 
-      // Update auth store with new tokens and user data
-      auth.login(response.accessToken, response.refreshToken, user);
+      // Update auth store with new token and user data
+      auth.login(response.accessToken, user);
 
       goto('/dashboard');
     } catch (err: any) {

--- a/lighthouse-front/src/routes/login/+page.svelte
+++ b/lighthouse-front/src/routes/login/+page.svelte
@@ -34,17 +34,17 @@
     try {
       const response = await authApi.login({ username, password, rememberMe });
 
-      // Store tokens
+      // Store the access token only. The refresh token is set by the backend as an
+      // HttpOnly cookie and is never exposed to JavaScript.
       if (typeof localStorage !== 'undefined') {
         localStorage.setItem('accessToken', response.accessToken);
-        localStorage.setItem('refreshToken', response.refreshToken);
       }
 
       // Fetch complete user data
       const user = await authApi.getCurrentUser();
 
       // Update auth store
-      auth.login(response.accessToken, response.refreshToken, user);
+      auth.login(response.accessToken, user);
 
       if (response.mustAddEmail) {
         goto('/add-email');
@@ -56,7 +56,6 @@
     } catch (err: any) {
       if (typeof localStorage !== 'undefined') {
         localStorage.removeItem('accessToken');
-        localStorage.removeItem('refreshToken');
       }
       // Extract detailed validation errors if available
       const responseData = err.response?.data;


### PR DESCRIPTION
## Contexte

Review complète back+front. Cette PR traite tous les items **🔴 critiques / élevés** identifiés.

## Fixes

| # | Fix |
|---|-----|
| 1.1 | **Rate limiting par-IP** — limiteurs FixedWindow partitionnés par IP client (X-Forwarded-For/X-Real-IP derrière nginx) ou user id, au lieu d'un compteur global partagé (DoS: un client pouvait épuiser la fenêtre auth et bloquer tout le monde). |
| 1.2 | **Audit admin-only** — `AuditController` en `Roles=admin` ; tout user authentifié pouvait lire l'intégralité des logs (IP, actions des autres). |
| 1.3 | **Path traversal** — comparaison root avec séparateur terminal ; un dossier voisin partageant le préfixe (`/app/compose-files-evil`) est rejeté. +2 tests. |
| 1.4 | **XSS** — `UserFormDialog` affiche l'erreur serveur en texte (`{error}`) au lieu de `{@html error}` (réfléchissait l'input). |
| 1.6 | **Info disclosure** — `/health/detailed` → admin, `/api/compose/health` → auth ; exposaient counts, version Docker, `ex.Message`. `/health` simple reste public (healthcheck Docker). |
| 1.5 | **Refresh token en cookie HttpOnly** — sorti de `localStorage` vers un cookie `lh_refresh` (HttpOnly, Secure si https, SameSite=Lax, Path=/api/auth), jamais en body ni lisible par JS. Rotation + révocation au logout. Front en `withCredentials`. |

## Vérification

Flow auth testé end-to-end (backend lancé, curl + cookie jar) :

- Login → 200, `Set-Cookie: lh_refresh; httponly`, body `refreshToken` vide
- Refresh via cookie → 200 + rotation
- Refresh sans cookie / réutilisation ancien cookie / après logout → 401
- Logout → cookie effacé

**Checks** : `dotnet build` 0 erreur · `dotnet test` **353/353** · `npm run check` 0 erreur.

## Reste ouvert (hors scope)

- 1.5 résiduel : access token (60 min) encore en `localStorage` — vecteur XSS neutralisé par 1.4 ; passage mémoire pure = hardening optionnel.
- 🟠 moyens : 1.9 (race refresh multi-onglets), 1.8 (`/me` factice), 1.12 (migration fail-fast), etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)