### PR TITLE
fix(security): sanitize changelog HTML + validate compose project names

### DIFF
--- a/lighthouse-back/lighthouse-back.Tests/Services/ComposeProjectNameValidatorTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/ComposeProjectNameValidatorTests.cs
@@ -1,0 +1,56 @@
+using Lighthouse.Utils;
+using FluentAssertions;
+
+namespace Lighthouse.Tests.Services;
+
+public class ComposeProjectNameValidatorTests
+{
+    [Theory]
+    [InlineData("myproject")]
+    [InlineData("my-project")]
+    [InlineData("my_project")]
+    [InlineData("my.project")]
+    [InlineData("Project1")]
+    [InlineData("a")]
+    [InlineData("123abc")]
+    public void IsValid_AcceptsSafeNames(string name)
+    {
+        ComposeProjectNameValidator.IsValid(name).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("-startsWithDash")]
+    [InlineData(".startsWithDot")]
+    [InlineData("has space")]
+    [InlineData("has\"quote")]
+    [InlineData("has'quote")]
+    [InlineData("has;semicolon")]
+    [InlineData("has|pipe")]
+    [InlineData("has/slash")]
+    [InlineData("has\\backslash")]
+    [InlineData("has$dollar")]
+    [InlineData("has`backtick")]
+    [InlineData("has\nnewline")]
+    [InlineData("has&amp")]
+    public void IsValid_RejectsUnsafeNames(string? name)
+    {
+        ComposeProjectNameValidator.IsValid(name).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValid_RejectsOverlyLongNames()
+    {
+        var longName = new string('a', ComposeProjectNameValidator.MaxLength + 1);
+        ComposeProjectNameValidator.IsValid(longName).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValid_AcceptsNameAtMaxLength()
+    {
+        var maxName = new string('a', ComposeProjectNameValidator.MaxLength);
+        ComposeProjectNameValidator.IsValid(maxName).Should().BeTrue();
+    }
+}

--- a/lighthouse-back/lighthouse-back/src/Services/ComposeOperationService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/ComposeOperationService.cs
@@ -1,4 +1,5 @@
 using Lighthouse.DTOs;
+using Lighthouse.Utils;
 
 namespace Lighthouse.Services;
 
@@ -22,6 +23,26 @@ public class ComposeOperationService : IComposeOperationService
         _discoveryService = discoveryService;
         _envFileResolver = envFileResolver;
         _logger = logger;
+    }
+
+    /// <summary>
+    /// Rejects project names that are not on the safe-character allowlist before they
+    /// are passed to the docker CLI. Returns a failure result to short-circuit, or null
+    /// when the name is valid.
+    /// </summary>
+    private OperationResult? RejectIfInvalidName(string projectName)
+    {
+        if (ComposeProjectNameValidator.IsValid(projectName))
+            return null;
+
+        _logger.LogWarning("Rejected compose operation for invalid project name: {ProjectName}", projectName);
+        return new OperationResult
+        {
+            Success = false,
+            Message = $"Invalid project name '{projectName}'",
+            Output = null,
+            Error = "Project name contains invalid characters"
+        };
     }
 
     /// <summary>
@@ -147,6 +168,9 @@ public class ComposeOperationService : IComposeOperationService
                 removeVolumes
             );
 
+            OperationResult? nameError = RejectIfInvalidName(projectName);
+            if (nameError != null) return nameError;
+
             // Validate project exists
             bool projectExists = await ValidateProjectExistsAsync(projectName);
             if (!projectExists)
@@ -215,6 +239,9 @@ public class ComposeOperationService : IComposeOperationService
         {
             _logger.LogDebug("Restarting compose project: {ProjectName}", projectName);
 
+            OperationResult? nameError = RejectIfInvalidName(projectName);
+            if (nameError != null) return nameError;
+
             // Validate project exists
             bool projectExists = await ValidateProjectExistsAsync(projectName);
             if (!projectExists)
@@ -282,6 +309,9 @@ public class ComposeOperationService : IComposeOperationService
         {
             _logger.LogDebug("Stopping compose project (without removing): {ProjectName}", projectName);
 
+            OperationResult? nameError = RejectIfInvalidName(projectName);
+            if (nameError != null) return nameError;
+
             // Validate project exists
             bool projectExists = await ValidateProjectExistsAsync(projectName);
             if (!projectExists)
@@ -348,6 +378,9 @@ public class ComposeOperationService : IComposeOperationService
         try
         {
             _logger.LogDebug("Starting previously stopped project: {ProjectName}", projectName);
+
+            OperationResult? nameError = RejectIfInvalidName(projectName);
+            if (nameError != null) return nameError;
 
             // Validate project exists
             bool projectExists = await ValidateProjectExistsAsync(projectName);

--- a/lighthouse-back/lighthouse-back/src/Utils/ComposeProjectNameValidator.cs
+++ b/lighthouse-back/lighthouse-back/src/Utils/ComposeProjectNameValidator.cs
@@ -1,0 +1,26 @@
+using System.Text.RegularExpressions;
+
+namespace Lighthouse.Utils;
+
+/// <summary>
+/// Validates compose project names before they are passed to the docker CLI as
+/// <c>-p "{projectName}"</c>. Although commands run with UseShellExecute=false (so there
+/// is no shell to inject into), an unvalidated name containing a quote or whitespace can
+/// still break argument parsing or target an unintended project. Names are restricted to
+/// an allowlist of safe characters.
+/// </summary>
+public static partial class ComposeProjectNameValidator
+{
+    // Must start with an alphanumeric, then allow alphanumerics plus _ . -
+    [GeneratedRegex(@"^[A-Za-z0-9][A-Za-z0-9_.-]*$")]
+    private static partial Regex ValidPattern();
+
+    public const int MaxLength = 255;
+
+    public static bool IsValid(string? projectName)
+    {
+        return !string.IsNullOrWhiteSpace(projectName)
+            && projectName.Length <= MaxLength
+            && ValidPattern().IsMatch(projectName);
+    }
+}

--- a/lighthouse-front/src/lib/components/update/ChangelogDisplay.svelte
+++ b/lighthouse-front/src/lib/components/update/ChangelogDisplay.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { ChevronDown, ChevronRight, AlertTriangle, Shield, ExternalLink, Tag } from 'lucide-svelte';
   import { marked } from 'marked';
+  import { sanitizeHtml } from '$lib/utils/sanitizeHtml';
   import { t } from '$lib/i18n';
   import Badge from '$lib/components/ui/badge.svelte';
   import type { ReleaseInfo, ChangelogSummary } from '$lib/types/update';
@@ -47,11 +48,16 @@
   }
 
   function renderMarkdown(text: string): string {
+    // Release notes come from GitHub and are injected via {@html}. Always run the
+    // output through the sanitizer (including the parse-failure fallback) to strip
+    // any scripts / event handlers / unsafe URLs.
+    let html: string;
     try {
-      return marked.parse(text) as string;
+      html = marked.parse(text) as string;
     } catch {
-      return text;
+      html = text;
     }
+    return sanitizeHtml(html);
   }
 </script>
 

--- a/lighthouse-front/src/lib/utils/sanitizeHtml.test.ts
+++ b/lighthouse-front/src/lib/utils/sanitizeHtml.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Force the browser code path so the DOMParser-based sanitizer runs (jsdom provides it).
+vi.mock('$app/environment', () => ({ browser: true }));
+
+import { sanitizeHtml } from './sanitizeHtml';
+
+describe('sanitizeHtml', () => {
+  it('keeps allowed formatting tags and text', () => {
+    const out = sanitizeHtml('<p>Hello <strong>world</strong> <em>!</em></p>');
+    expect(out).toBe('<p>Hello <strong>world</strong> <em>!</em></p>');
+  });
+
+  it('removes script elements entirely', () => {
+    const out = sanitizeHtml('<p>ok</p><script>alert(1)</script>');
+    expect(out).toContain('<p>ok</p>');
+    expect(out.toLowerCase()).not.toContain('<script');
+    expect(out).not.toContain('alert(1)');
+  });
+
+  it('strips inline event handlers', () => {
+    const out = sanitizeHtml('<a href="https://ex.com" onclick="steal()">x</a>');
+    expect(out).not.toContain('onclick');
+    expect(out).not.toContain('steal');
+    expect(out).toContain('href="https://ex.com"');
+  });
+
+  it('drops javascript: URLs on href', () => {
+    const out = sanitizeHtml('<a href="javascript:alert(1)">x</a>');
+    expect(out).not.toContain('javascript:');
+    expect(out).toContain('>x</a>');
+  });
+
+  it('drops javascript: URLs smuggled with control chars', () => {
+    const out = sanitizeHtml('<a href="java\tscript:alert(1)">x</a>');
+    expect(out.toLowerCase()).not.toContain('script:');
+  });
+
+  it('drops data: URLs on img src', () => {
+    const out = sanitizeHtml('<img src="data:text/html;base64,PHN2Zz4=" alt="x">');
+    expect(out).not.toContain('data:');
+  });
+
+  it('keeps safe http/mailto/relative/anchor URLs', () => {
+    expect(sanitizeHtml('<a href="https://a.com">a</a>')).toContain('href="https://a.com"');
+    expect(sanitizeHtml('<a href="mailto:x@y.com">a</a>')).toContain('href="mailto:x@y.com"');
+    expect(sanitizeHtml('<a href="/rel">a</a>')).toContain('href="/rel"');
+    expect(sanitizeHtml('<a href="#frag">a</a>')).toContain('href="#frag"');
+  });
+
+  it('removes iframe/object/style elements', () => {
+    const out = sanitizeHtml('<iframe src="https://evil"></iframe><style>*{}</style><b>keep</b>');
+    expect(out.toLowerCase()).not.toContain('<iframe');
+    expect(out.toLowerCase()).not.toContain('<style');
+    expect(out).toContain('<b>keep</b>');
+  });
+
+  it('adds rel=noopener to target=_blank links', () => {
+    const out = sanitizeHtml('<a href="https://a.com" target="_blank">a</a>');
+    expect(out).toContain('rel="noopener noreferrer"');
+  });
+});

--- a/lighthouse-front/src/lib/utils/sanitizeHtml.ts
+++ b/lighthouse-front/src/lib/utils/sanitizeHtml.ts
@@ -1,0 +1,93 @@
+import { browser } from '$app/environment';
+
+// Minimal, dependency-free HTML sanitizer for rendering trusted-ish markdown output
+// (e.g. GitHub release notes) via {@html}. It parses the HTML, then walks the tree and
+// drops anything not on the allowlist: disallowed elements are removed entirely,
+// disallowed attributes are stripped, and URL attributes are restricted to safe
+// schemes. This is intentionally conservative — it is not a general-purpose sanitizer,
+// only enough to neutralize scripts, event handlers and javascript:/data: URLs in
+// changelog content.
+
+const ALLOWED_TAGS = new Set([
+  'a', 'p', 'br', 'hr', 'span', 'div',
+  'strong', 'b', 'em', 'i', 'u', 'del', 's', 'small', 'sub', 'sup',
+  'code', 'pre', 'kbd', 'samp',
+  'ul', 'ol', 'li',
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'blockquote',
+  'table', 'thead', 'tbody', 'tfoot', 'tr', 'th', 'td',
+  'img'
+]);
+
+// Attributes allowed per tag (plus the global set below).
+const ALLOWED_ATTRS: Record<string, Set<string>> = {
+  a: new Set(['href', 'title', 'target', 'rel']),
+  img: new Set(['src', 'alt', 'title', 'width', 'height'])
+};
+const GLOBAL_ALLOWED_ATTRS = new Set(['title']);
+
+// URL attributes whose value must use a safe scheme.
+const URL_ATTRS = new Set(['href', 'src']);
+const SAFE_URL = /^(https?:|mailto:|#|\/)/i;
+
+function isSafeUrl(value: string): boolean {
+  // Strip control chars and spaces (code point <= 0x20) before testing the scheme:
+  // browsers ignore embedded control chars, so "java\tscript:alert(1)" resolves to
+  // javascript:. Filtering by code point avoids putting control chars in this source.
+  const cleaned = Array.from(value)
+    .filter((ch) => ch.charCodeAt(0) > 0x20)
+    .join('');
+  if (cleaned === '') return false;
+  return SAFE_URL.test(cleaned);
+}
+
+function sanitizeElement(el: Element): void {
+  const tag = el.tagName.toLowerCase();
+
+  // Remove disallowed elements entirely (including their subtree). script/style/iframe
+  // etc. never reach here on the allowlist.
+  if (!ALLOWED_TAGS.has(tag)) {
+    el.remove();
+    return;
+  }
+
+  // Strip disallowed / dangerous attributes.
+  for (const attr of Array.from(el.attributes)) {
+    const name = attr.name.toLowerCase();
+    const perTag = ALLOWED_ATTRS[tag];
+    const allowed = GLOBAL_ALLOWED_ATTRS.has(name) || (perTag?.has(name) ?? false);
+
+    if (!allowed || name.startsWith('on')) {
+      el.removeAttribute(attr.name);
+      continue;
+    }
+
+    if (URL_ATTRS.has(name) && !isSafeUrl(attr.value)) {
+      el.removeAttribute(attr.name);
+    }
+  }
+
+  // Harden external links.
+  if (tag === 'a' && el.getAttribute('target') === '_blank') {
+    el.setAttribute('rel', 'noopener noreferrer');
+  }
+
+  // Recurse (snapshot children first — the list mutates as we remove nodes).
+  for (const child of Array.from(el.children)) {
+    sanitizeElement(child);
+  }
+}
+
+/**
+ * Sanitize an HTML string, returning markup safe to inject with {@html}.
+ * Returns an empty string outside the browser (no DOMParser available).
+ */
+export function sanitizeHtml(html: string): string {
+  if (!browser) return '';
+
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  for (const child of Array.from(doc.body.children)) {
+    sanitizeElement(child);
+  }
+  return doc.body.innerHTML;
+}


### PR DESCRIPTION
Suite de la review — 🟠 sécurité (sanitizer maison sans dep, comme convenu).

## Fixes

| # | Fix |
|---|-----|
| 1.13 | **XSS changelog** — les release notes GitHub étaient rendues via `{@html marked.parse(...)}` sans sanitize. Ajout d'un sanitizer **sans dépendance** (`lib/utils/sanitizeHtml`) : parse le HTML, garde une allowlist de tags/attrs, supprime `script`/`style`/`iframe`/…, strip les handlers `on*`, restreint `href`/`src` aux schémas sûrs (bloque `javascript:`/`data:`, y compris smuggling par control-chars). Le fallback en cas d'échec de parse est sanitizé aussi. |
| 1.14 | **Validation projectName** — rejet des noms hors allowlist (`[A-Za-z0-9][A-Za-z0-9_.-]*`, max 255) avant passage à `docker ... -p "{name}"`. Appliqué au choke point `ComposeOperationService` (down/stop/start/restart) → couvre tous les appelants. Pas de shell (`UseShellExecute=false`), mais évite qu'un guillemet/espace casse le parsing d'arguments ou cible un autre projet. |

## Tests

- **+9** tests sanitizer (front) : tags autorisés, script/iframe/style supprimés, `on*` strippés, `javascript:`/`data:` bloqués (dont control-char smuggling), `rel=noopener` sur `target=_blank`.
- **+25** tests validateur (back) : noms sûrs acceptés, injections/espaces/quotes/longueur rejetés.

**Checks** : `dotnet build` 0 err · `dotnet test` **378/378** · `vitest` **31/31** · `npm run check` 0 err · `npm run build` OK.

## Reste (à discuter ensuite)

- 1.10 (détection réutilisation refresh) et 1.11 (révocation access token) — décisions de schéma/archi, je présenterai les options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)