### PR TITLE
feat(security): refresh token reuse detection + access token revocation (1.10 + 1.11)

### DIFF
--- a/lighthouse-back/lighthouse-back.Tests/Services/AuthServiceTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/AuthServiceTests.cs
@@ -1,0 +1,148 @@
+using Lighthouse.Data;
+using Lighthouse.DTOs;
+using Lighthouse.Models;
+using Lighthouse.Services;
+using DockerComposeManager.Services.Security;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Lighthouse.Tests.Services;
+
+public class AuthServiceTests
+{
+    private static AppDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var ctx = new AppDbContext(options);
+        ctx.Roles.Add(new Role { Id = 1, Name = "user", Permissions = "[]" });
+        ctx.Users.Add(new User
+        {
+            Id = 1,
+            Username = "alice",
+            PasswordHash = "stored-hash",
+            RoleId = 1,
+            IsEnabled = true,
+            SecurityStamp = "stamp-1"
+        });
+        ctx.SaveChanges();
+        return ctx;
+    }
+
+    private static AuthService NewService(AppDbContext ctx, IMemoryCache? cache = null)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Secret"] = "test-secret-key-at-least-32-characters-long",
+                ["Jwt:Issuer"] = "lighthouse",
+                ["Jwt:Audience"] = "lighthouse-client",
+                ["Jwt:ExpirationMinutes"] = "15",
+                ["Jwt:RefreshExpirationDays"] = "1"
+            })
+            .Build();
+
+        var jwt = new JwtTokenService(config);
+
+        var hasher = new Mock<IPasswordHasher>();
+        hasher.Setup(h => h.VerifyPassword("correct", "stored-hash")).Returns(true);
+        hasher.Setup(h => h.HashPassword(It.IsAny<string>())).Returns<string>(p => "hashed:" + p);
+
+        return new AuthService(
+            ctx, jwt, config, hasher.Object,
+            cache ?? new MemoryCache(new MemoryCacheOptions()),
+            NullLogger<AuthService>.Instance);
+    }
+
+    [Fact]
+    public async Task Login_StoresHashedRefreshToken_NotRaw()
+    {
+        using var ctx = NewContext();
+        var svc = NewService(ctx);
+
+        var (success, response, _, _) = await svc.LoginAsync(
+            new LoginRequest("alice", "correct"), "ip", "device");
+
+        success.Should().BeTrue();
+        var raw = response!.RefreshToken;
+        raw.Should().NotBeNullOrEmpty();
+
+        var stored = await ctx.Sessions.SingleAsync();
+        stored.RefreshToken.Should().NotBe(raw, "the raw token must not be stored in clear");
+        stored.FamilyId.Should().NotBeNullOrEmpty();
+        stored.IsUsed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Refresh_RotatesToken_AndConsumesOld()
+    {
+        using var ctx = NewContext();
+        var svc = NewService(ctx);
+
+        var login = (await svc.LoginAsync(new LoginRequest("alice", "correct"), "ip", "d")).Response!;
+        var (success, refreshed, _, _) = await svc.RefreshTokenAsync(login.RefreshToken, "ip");
+
+        success.Should().BeTrue();
+        refreshed!.RefreshToken.Should().NotBe(login.RefreshToken);
+
+        // Old token row is consumed; a new one exists in the same family.
+        var families = await ctx.Sessions.Select(s => s.FamilyId).Distinct().ToListAsync();
+        families.Should().HaveCount(1);
+        (await ctx.Sessions.CountAsync(s => s.IsUsed)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Refresh_ReusedOldToken_RevokesEntireFamily()
+    {
+        using var ctx = NewContext();
+        var svc = NewService(ctx);
+
+        var login = (await svc.LoginAsync(new LoginRequest("alice", "correct"), "ip", "d")).Response!;
+        var rotated = (await svc.RefreshTokenAsync(login.RefreshToken, "ip")).Response!;
+
+        // Replay the ORIGINAL (now consumed) token -> reuse detected.
+        var (reuseSuccess, _, _, _) = await svc.RefreshTokenAsync(login.RefreshToken, "ip");
+        reuseSuccess.Should().BeFalse();
+
+        // The whole family is revoked: the legitimately rotated token no longer works.
+        var (afterRevoke, _, _, _) = await svc.RefreshTokenAsync(rotated.RefreshToken, "ip");
+        afterRevoke.Should().BeFalse();
+
+        (await ctx.Sessions.CountAsync(s => s.RevokedAt == null)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Logout_RevokesFamily_TokenNoLongerRefreshable()
+    {
+        using var ctx = NewContext();
+        var svc = NewService(ctx);
+
+        var login = (await svc.LoginAsync(new LoginRequest("alice", "correct"), "ip", "d")).Response!;
+
+        (await svc.LogoutAsync(login.RefreshToken)).Should().BeTrue();
+
+        var (success, _, _, _) = await svc.RefreshTokenAsync(login.RefreshToken, "ip");
+        success.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ChangePassword_RotatesSecurityStamp_AndInvalidatesCache()
+    {
+        using var ctx = NewContext();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        cache.Set(Lighthouse.Services.Security.SecurityStampCache.Key(1), "stale");
+        var svc = NewService(ctx, cache);
+
+        var (success, _, _, _) = await svc.ChangePasswordAsync(1, "correct", "newpass", "ip", "ua");
+
+        success.Should().BeTrue();
+        var user = await ctx.Users.SingleAsync();
+        user.SecurityStamp.Should().NotBe("stamp-1");
+        cache.TryGetValue(Lighthouse.Services.Security.SecurityStampCache.Key(1), out _).Should().BeFalse();
+    }
+}

--- a/lighthouse-back/lighthouse-back.Tests/Services/UserServiceTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/UserServiceTests.cs
@@ -4,6 +4,7 @@ using Lighthouse.Models;
 using Lighthouse.Services;
 using DockerComposeManager.Services.Security;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Moq;
 
@@ -44,7 +45,7 @@ public class UserServiceTests
         );
         await context.SaveChangesAsync();
 
-        var service = new UserService(context, logger.Object, auditService.Object, passwordHasher.Object);
+        var service = new UserService(context, logger.Object, auditService.Object, passwordHasher.Object, new MemoryCache(new MemoryCacheOptions()));
 
         // Act
         List<UserDto> users = await service.GetAllUsersAsync();
@@ -64,7 +65,7 @@ public class UserServiceTests
         var auditService = new Mock<IAuditService>();
         var passwordHasher = new Mock<IPasswordHasher>();
         passwordHasher.Setup(p => p.HashPassword(It.IsAny<string>())).Returns("hashed_password");
-        var service = new UserService(context, logger.Object, auditService.Object, passwordHasher.Object);
+        var service = new UserService(context, logger.Object, auditService.Object, passwordHasher.Object, new MemoryCache(new MemoryCacheOptions()));
 
         var request = new CreateUserRequest("testuser", "password123", "user");
 
@@ -103,7 +104,7 @@ public class UserServiceTests
         });
         await context.SaveChangesAsync();
 
-        var service = new UserService(context, logger.Object, auditService.Object, passwordHasher.Object);
+        var service = new UserService(context, logger.Object, auditService.Object, passwordHasher.Object, new MemoryCache(new MemoryCacheOptions()));
         var request = new CreateUserRequest("existinguser", "password123", "user");
 
         // Act & Assert
@@ -131,7 +132,7 @@ public class UserServiceTests
         context.Users.Add(adminUser);
         await context.SaveChangesAsync();
 
-        var service = new UserService(context, logger.Object, auditService.Object, passwordHasher.Object);
+        var service = new UserService(context, logger.Object, auditService.Object, passwordHasher.Object, new MemoryCache(new MemoryCacheOptions()));
 
         // Act & Assert
         InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.DeleteUserAsync(1));
@@ -159,7 +160,7 @@ public class UserServiceTests
         context.Users.Add(user);
         await context.SaveChangesAsync();
 
-        var service = new UserService(context, logger.Object, auditService.Object, passwordHasher.Object);
+        var service = new UserService(context, logger.Object, auditService.Object, passwordHasher.Object, new MemoryCache(new MemoryCacheOptions()));
         var request = new UpdateUserRequest(Role: "admin", IsEnabled: null, NewPassword: null);
 
         // Act
@@ -191,7 +192,7 @@ public class UserServiceTests
         context.Users.Add(user);
         await context.SaveChangesAsync();
 
-        var service = new UserService(context, logger.Object, auditService.Object, passwordHasher.Object);
+        var service = new UserService(context, logger.Object, auditService.Object, passwordHasher.Object, new MemoryCache(new MemoryCacheOptions()));
 
         // Act
         UserDto result = await service.EnableUserAsync(1);
@@ -215,7 +216,7 @@ public class UserServiceTests
         );
         await context.SaveChangesAsync();
 
-        var service = new UserService(context, logger.Object, auditService.Object, passwordHasher.Object);
+        var service = new UserService(context, logger.Object, auditService.Object, passwordHasher.Object, new MemoryCache(new MemoryCacheOptions()));
 
         // Act
         UserDto result = await service.DisableUserAsync(2);

--- a/lighthouse-back/lighthouse-back/Migrations/20260703173944_AddRefreshTokenFamilyAndSecurityStamp.Designer.cs
+++ b/lighthouse-back/lighthouse-back/Migrations/20260703173944_AddRefreshTokenFamilyAndSecurityStamp.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Lighthouse.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Lighthouse.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260703173944_AddRefreshTokenFamilyAndSecurityStamp")]
+    partial class AddRefreshTokenFamilyAndSecurityStamp
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.9");

--- a/lighthouse-back/lighthouse-back/Migrations/20260703173944_AddRefreshTokenFamilyAndSecurityStamp.cs
+++ b/lighthouse-back/lighthouse-back/Migrations/20260703173944_AddRefreshTokenFamilyAndSecurityStamp.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Lighthouse.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefreshTokenFamilyAndSecurityStamp : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SecurityStamp",
+                table: "Users",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "FamilyId",
+                table: "Sessions",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsUsed",
+                table: "Sessions",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "RevokedAt",
+                table: "Sessions",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "SecurityStamp",
+                value: "00000000000000000000000000000001");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sessions_FamilyId",
+                table: "Sessions",
+                column: "FamilyId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Sessions_FamilyId",
+                table: "Sessions");
+
+            migrationBuilder.DropColumn(
+                name: "SecurityStamp",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "FamilyId",
+                table: "Sessions");
+
+            migrationBuilder.DropColumn(
+                name: "IsUsed",
+                table: "Sessions");
+
+            migrationBuilder.DropColumn(
+                name: "RevokedAt",
+                table: "Sessions");
+        }
+    }
+}

--- a/lighthouse-back/lighthouse-back/Program.cs
+++ b/lighthouse-back/lighthouse-back/Program.cs
@@ -10,6 +10,7 @@ using FluentValidation;
 using FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using Serilog;
@@ -146,6 +147,40 @@ builder.Services.AddAuthentication(options =>
             }
 
             return Task.CompletedTask;
+        },
+
+        // Enforce the per-user security stamp so access tokens can be revoked before
+        // their natural expiry (password change, disable, role change). The current
+        // stamp/enabled state is cached briefly to avoid a DB hit on every request.
+        OnTokenValidated = async context =>
+        {
+            string? idClaim = context.Principal?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+            string? stampClaim = context.Principal?.FindFirst("sstamp")?.Value;
+
+            if (!int.TryParse(idClaim, out int uid) || string.IsNullOrEmpty(stampClaim))
+            {
+                context.Fail("Invalid token subject");
+                return;
+            }
+
+            Microsoft.Extensions.Caching.Memory.IMemoryCache cache =
+                context.HttpContext.RequestServices.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>();
+
+            Lighthouse.Services.Security.UserSecurityInfo? info =
+                await cache.GetOrCreateAsync(Lighthouse.Services.Security.SecurityStampCache.Key(uid), async entry =>
+                {
+                    entry.AbsoluteExpirationRelativeToNow = Lighthouse.Services.Security.SecurityStampCache.Ttl;
+                    AppDbContext db = context.HttpContext.RequestServices.GetRequiredService<AppDbContext>();
+                    return await db.Users
+                        .Where(u => u.Id == uid)
+                        .Select(u => new Lighthouse.Services.Security.UserSecurityInfo(u.SecurityStamp, u.IsEnabled))
+                        .FirstOrDefaultAsync();
+                });
+
+            if (info is null || !info.IsEnabled || info.SecurityStamp != stampClaim)
+            {
+                context.Fail("Security stamp mismatch");
+            }
         }
     };
 });

--- a/lighthouse-back/lighthouse-back/appsettings.Development.json
+++ b/lighthouse-back/lighthouse-back/appsettings.Development.json
@@ -12,7 +12,7 @@
     "Secret": "dev-secret-key-at-least-32-chars-long-for-jwt-signing",
     "Issuer": "lighthouse",
     "Audience": "lighthouse-client",
-    "ExpirationMinutes": 60,
+    "ExpirationMinutes": 15,
     "RefreshExpirationDays": 1,
     "RefreshExpirationDaysExtended": 30
   },

--- a/lighthouse-back/lighthouse-back/appsettings.json
+++ b/lighthouse-back/lighthouse-back/appsettings.json
@@ -13,7 +13,7 @@
     "Secret": "CHANGE-THIS-SECRET-KEY-IN-PRODUCTION-MIN-32-CHARS",
     "Issuer": "lighthouse",
     "Audience": "lighthouse-client",
-    "ExpirationMinutes": 60,
+    "ExpirationMinutes": 15,
     "RefreshExpirationDays": 1,
     "RefreshExpirationDaysExtended": 30
   },

--- a/lighthouse-back/lighthouse-back/src/BackgroundServices/CleanupBackgroundService.cs
+++ b/lighthouse-back/lighthouse-back/src/BackgroundServices/CleanupBackgroundService.cs
@@ -59,6 +59,14 @@ public class CleanupBackgroundService : BackgroundService
                 {
                     _logger.LogInformation("Operation cleanup completed. Deleted {Count} old operations", operationDeletedCount);
                 }
+
+                // Cleanup expired / long-revoked refresh sessions
+                AuthService authService = scope.ServiceProvider.GetRequiredService<AuthService>();
+                var sessionDeletedCount = await authService.CleanupExpiredSessionsAsync();
+                if (sessionDeletedCount > 0)
+                {
+                    _logger.LogInformation("Session cleanup completed. Deleted {Count} stale sessions", sessionDeletedCount);
+                }
             }
             catch (OperationCanceledException)
             {

--- a/lighthouse-back/lighthouse-back/src/Data/AppDbContext.cs
+++ b/lighthouse-back/lighthouse-back/src/Data/AppDbContext.cs
@@ -55,6 +55,7 @@ public class AppDbContext : DbContext
         {
             entity.HasKey(e => e.Id);
             entity.HasIndex(e => e.RefreshToken).IsUnique();
+            entity.HasIndex(e => e.FamilyId);
             entity.HasOne(e => e.User)
                 .WithMany(u => u.Sessions)
                 .HasForeignKey(e => e.UserId)
@@ -204,6 +205,8 @@ public class AppDbContext : DbContext
                 IsEnabled = true,
                 MustChangePassword = true,
                 MustAddEmail = true,
+                // Fixed value so the seed stays deterministic across migrations.
+                SecurityStamp = "00000000000000000000000000000001",
                 CreatedAt = seedDate
             }
         );

--- a/lighthouse-back/lighthouse-back/src/Models/Session.cs
+++ b/lighthouse-back/lighthouse-back/src/Models/Session.cs
@@ -4,7 +4,32 @@ public class Session
 {
     public int Id { get; set; }
     public int UserId { get; set; }
+
+    /// <summary>
+    /// SHA-256 hash (hex) of the refresh token. The raw token is only ever held by the
+    /// client (HttpOnly cookie); storing a hash means a database leak does not expose
+    /// usable refresh tokens.
+    /// </summary>
     public required string RefreshToken { get; set; }
+
+    /// <summary>
+    /// Identifies the rotation lineage: every refresh of a single login shares one
+    /// FamilyId. Used to revoke the whole family when token reuse is detected.
+    /// </summary>
+    public required string FamilyId { get; set; }
+
+    /// <summary>
+    /// True once this token has been rotated (consumed). Presenting a used token again
+    /// signals theft and triggers revocation of the entire family.
+    /// </summary>
+    public bool IsUsed { get; set; }
+
+    /// <summary>
+    /// Set when the family is revoked (reuse detected, or logout). A revoked token can
+    /// never be refreshed again.
+    /// </summary>
+    public DateTime? RevokedAt { get; set; }
+
     public required string DeviceInfo { get; set; }
     public required string IpAddress { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/lighthouse-back/lighthouse-back/src/Models/User.cs
+++ b/lighthouse-back/lighthouse-back/src/Models/User.cs
@@ -14,6 +14,13 @@ public class User
     public bool IsEnabled { get; set; } = true;
     public bool MustChangePassword { get; set; } = false;
     public bool MustAddEmail { get; set; } = false;
+
+    /// <summary>
+    /// Rotated whenever the account's security context changes (password change, disable,
+    /// role change). Embedded in access tokens as the "sstamp" claim and checked on every
+    /// request, so a stamp change invalidates all outstanding access tokens near-instantly.
+    /// </summary>
+    public string SecurityStamp { get; set; } = Guid.NewGuid().ToString("N");
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime? UpdatedAt { get; set; }
     public DateTime? LastLoginAt { get; set; }

--- a/lighthouse-back/lighthouse-back/src/Services/AuthService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/AuthService.cs
@@ -1,7 +1,11 @@
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Lighthouse.Data;
 using Lighthouse.Models;
 using Lighthouse.DTOs;
+using Lighthouse.Services.Security;
 using DockerComposeManager.Services.Security;
 
 namespace Lighthouse.Services;
@@ -12,17 +16,33 @@ public class AuthService
     private readonly JwtTokenService _jwtService;
     private readonly IConfiguration _configuration;
     private readonly IPasswordHasher _passwordHasher;
+    private readonly IMemoryCache _cache;
+    private readonly ILogger<AuthService> _logger;
 
     public AuthService(
         AppDbContext context,
         JwtTokenService jwtService,
         IConfiguration configuration,
-        IPasswordHasher passwordHasher)
+        IPasswordHasher passwordHasher,
+        IMemoryCache cache,
+        ILogger<AuthService> logger)
     {
         _context = context;
         _jwtService = jwtService;
         _configuration = configuration;
         _passwordHasher = passwordHasher;
+        _cache = cache;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// SHA-256 hash (hex) of a refresh token. Only the hash is persisted; the raw token
+    /// stays in the client's HttpOnly cookie.
+    /// </summary>
+    private static string HashToken(string rawToken)
+    {
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(rawToken));
+        return Convert.ToHexString(hash);
     }
 
     public async Task<(bool Success, LoginResponse? Response, DateTime? RefreshExpiresAt, string? Error)> LoginAsync(LoginRequest request, string ipAddress, string deviceInfo)
@@ -51,11 +71,13 @@ public class AuthService
             : int.Parse(_configuration["Jwt:RefreshExpirationDays"] ?? "1");
         var expiresAt = DateTime.UtcNow.AddDays(refreshExpirationDays);
 
-        // Create session
+        // New login starts a fresh refresh-token family.
         var session = new Session
         {
             UserId = user.Id,
-            RefreshToken = refreshToken,
+            RefreshToken = HashToken(refreshToken),
+            FamilyId = Guid.NewGuid().ToString("N"),
+            IsUsed = false,
             DeviceInfo = deviceInfo,
             IpAddress = ipAddress,
             CreatedAt = DateTime.UtcNow,
@@ -84,25 +106,56 @@ public class AuthService
 
     public async Task<(bool Success, LoginResponse? Response, DateTime? RefreshExpiresAt, string? Error)> RefreshTokenAsync(string refreshToken, string ipAddress)
     {
+        var tokenHash = HashToken(refreshToken);
+
         var session = await _context.Sessions
             .Include(s => s.User)
                 .ThenInclude(u => u.Role)
-            .FirstOrDefaultAsync(s => s.RefreshToken == refreshToken);
+            .FirstOrDefaultAsync(s => s.RefreshToken == tokenHash);
 
-        if (session == null || session.ExpiresAt < DateTime.UtcNow || !session.User.IsEnabled)
+        if (session == null)
         {
             return (false, null, null, "Invalid or expired refresh token");
         }
 
-        // Update session
-        session.LastUsedAt = DateTime.UtcNow;
+        // Reuse detection: a token that was already rotated (or belongs to a revoked
+        // family) is being presented again -> likely theft. Revoke the whole family so
+        // neither the attacker nor the victim can keep using it.
+        if (session.IsUsed || session.RevokedAt != null)
+        {
+            _logger.LogWarning(
+                "Refresh token reuse detected for user {UserId}, family {FamilyId}. Revoking family.",
+                session.UserId, session.FamilyId);
+            await RevokeFamilyAsync(session.UserId, session.FamilyId);
+            return (false, null, null, "Invalid or expired refresh token");
+        }
 
-        // Generate new tokens
+        if (session.ExpiresAt < DateTime.UtcNow || !session.User.IsEnabled)
+        {
+            return (false, null, null, "Invalid or expired refresh token");
+        }
+
+        // Rotate: consume the current token and issue a new one in the same family.
         var accessToken = _jwtService.GenerateAccessToken(session.User);
         var newRefreshToken = _jwtService.GenerateRefreshToken();
 
-        // Update refresh token in session
-        session.RefreshToken = newRefreshToken;
+        session.IsUsed = true;
+        session.LastUsedAt = DateTime.UtcNow;
+
+        var newSession = new Session
+        {
+            UserId = session.UserId,
+            RefreshToken = HashToken(newRefreshToken),
+            FamilyId = session.FamilyId,
+            IsUsed = false,
+            DeviceInfo = session.DeviceInfo,
+            IpAddress = ipAddress,
+            CreatedAt = DateTime.UtcNow,
+            // Rotation keeps the original family expiry (no sliding window here).
+            ExpiresAt = session.ExpiresAt,
+            LastUsedAt = DateTime.UtcNow
+        };
+        _context.Sessions.Add(newSession);
 
         await _context.SaveChangesAsync();
 
@@ -115,22 +168,40 @@ public class AuthService
             session.User.MustAddEmail
         );
 
-        // Refresh token rotation keeps the original session expiry (no sliding window here).
         return (true, response, session.ExpiresAt, null);
     }
 
     public async Task<bool> LogoutAsync(string refreshToken)
     {
-        var session = await _context.Sessions.FirstOrDefaultAsync(s => s.RefreshToken == refreshToken);
+        var tokenHash = HashToken(refreshToken);
+        var session = await _context.Sessions.FirstOrDefaultAsync(s => s.RefreshToken == tokenHash);
 
         if (session != null)
         {
-            _context.Sessions.Remove(session);
-            await _context.SaveChangesAsync();
+            // Revoke the entire family so no rotated token from this login remains usable.
+            await RevokeFamilyAsync(session.UserId, session.FamilyId);
             return true;
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Marks every non-revoked token in a family as revoked.
+    /// </summary>
+    private async Task RevokeFamilyAsync(int userId, string familyId)
+    {
+        var now = DateTime.UtcNow;
+        var familySessions = await _context.Sessions
+            .Where(s => s.UserId == userId && s.FamilyId == familyId && s.RevokedAt == null)
+            .ToListAsync();
+
+        foreach (var s in familySessions)
+        {
+            s.RevokedAt = now;
+        }
+
+        await _context.SaveChangesAsync();
     }
 
     public async Task<(bool Success, string? AccessToken, string? RefreshToken, DateTime? RefreshExpiresAt)> ChangePasswordAsync(int userId, string currentPassword, string newPassword, string ipAddress, string userAgent)
@@ -148,11 +219,16 @@ public class AuthService
         user.MustChangePassword = false;
         user.UpdatedAt = DateTime.UtcNow;
 
-        // Invalidate all OLD sessions for security
+        // Rotate the security stamp so all previously issued access tokens are rejected,
+        // and drop the cached copy so it takes effect immediately.
+        user.SecurityStamp = Guid.NewGuid().ToString("N");
+        SecurityStampCache.Invalidate(_cache, user.Id);
+
+        // Invalidate all OLD refresh sessions for security
         var sessions = await _context.Sessions.Where(s => s.UserId == userId).ToListAsync();
         _context.Sessions.RemoveRange(sessions);
 
-        // Create a new session with new tokens
+        // Create a new session (new family) with new tokens
         var accessToken = _jwtService.GenerateAccessToken(user);
         var refreshToken = _jwtService.GenerateRefreshToken();
         var expiresAt = DateTime.UtcNow.AddDays(
@@ -161,11 +237,14 @@ public class AuthService
         var newSession = new Session
         {
             UserId = user.Id,
-            RefreshToken = refreshToken,
+            RefreshToken = HashToken(refreshToken),
+            FamilyId = Guid.NewGuid().ToString("N"),
+            IsUsed = false,
             ExpiresAt = expiresAt,
             IpAddress = ipAddress,
             DeviceInfo = userAgent,
-            CreatedAt = DateTime.UtcNow
+            CreatedAt = DateTime.UtcNow,
+            LastUsedAt = DateTime.UtcNow
         };
 
         _context.Sessions.Add(newSession);
@@ -198,5 +277,27 @@ public class AuthService
 
         await _context.SaveChangesAsync();
         return true;
+    }
+
+    /// <summary>
+    /// Removes sessions that are expired or were revoked more than the grace period ago.
+    /// Used/expired rows are kept briefly so reuse detection still works right after rotation.
+    /// </summary>
+    public async Task<int> CleanupExpiredSessionsAsync(TimeSpan? revokedGrace = null)
+    {
+        var grace = revokedGrace ?? TimeSpan.FromDays(1);
+        var now = DateTime.UtcNow;
+        var revokedCutoff = now - grace;
+
+        var stale = await _context.Sessions
+            .Where(s => s.ExpiresAt < now || (s.RevokedAt != null && s.RevokedAt < revokedCutoff))
+            .ToListAsync();
+
+        if (stale.Count == 0)
+            return 0;
+
+        _context.Sessions.RemoveRange(stale);
+        await _context.SaveChangesAsync();
+        return stale.Count;
     }
 }

--- a/lighthouse-back/lighthouse-back/src/Services/JwtTokenService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/JwtTokenService.cs
@@ -21,7 +21,7 @@ public class JwtTokenService
         var secret = _configuration["Jwt:Secret"] ?? throw new InvalidOperationException("JWT Secret not configured");
         var issuer = _configuration["Jwt:Issuer"] ?? "lighthouse";
         var audience = _configuration["Jwt:Audience"] ?? "lighthouse-client";
-        var expirationMinutes = int.Parse(_configuration["Jwt:ExpirationMinutes"] ?? "60");
+        var expirationMinutes = int.Parse(_configuration["Jwt:ExpirationMinutes"] ?? "15");
 
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret));
         var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
@@ -31,6 +31,9 @@ public class JwtTokenService
             new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
             new Claim(ClaimTypes.Name, user.Username),
             new Claim(ClaimTypes.Role, user.Role?.Name ?? "user"),
+            // Security stamp: checked on every request so the token can be revoked
+            // (password change, disable, role change) before its natural expiry.
+            new Claim("sstamp", user.SecurityStamp),
             new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
             new Claim(JwtRegisteredClaimNames.Iat, DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString())
         };

--- a/lighthouse-back/lighthouse-back/src/Services/PasswordResetService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/PasswordResetService.cs
@@ -1,11 +1,13 @@
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using Lighthouse.Configuration;
 using Lighthouse.Data;
 using Lighthouse.Models;
 using Lighthouse.Services.Email;
+using Lighthouse.Services.Security;
 using DockerComposeManager.Services.Security;
 
 namespace Lighthouse.Services;
@@ -17,19 +19,22 @@ public class PasswordResetService : IPasswordResetService
     private readonly IPasswordHasher _passwordHasher;
     private readonly ILogger<PasswordResetService> _logger;
     private readonly PasswordResetOptions _options;
+    private readonly IMemoryCache _cache;
 
     public PasswordResetService(
         AppDbContext context,
         IEmailService emailService,
         IPasswordHasher passwordHasher,
         ILogger<PasswordResetService> logger,
-        IOptions<PasswordResetOptions> options)
+        IOptions<PasswordResetOptions> options,
+        IMemoryCache cache)
     {
         _context = context;
         _emailService = emailService;
         _passwordHasher = passwordHasher;
         _logger = logger;
         _options = options.Value;
+        _cache = cache;
     }
 
     public async Task<(bool Success, string? Error)> CreateResetTokenAsync(string usernameOrEmail, string ipAddress)
@@ -203,6 +208,10 @@ public class PasswordResetService : IPasswordResetService
             user.PasswordHash = newPasswordHash;
             user.MustChangePassword = false;
             user.UpdatedAt = DateTime.UtcNow;
+
+            // Rotate the security stamp so any outstanding access tokens are rejected.
+            user.SecurityStamp = Guid.NewGuid().ToString("N");
+            SecurityStampCache.Invalidate(_cache, user.Id);
 
             // Mark token as used
             var tokenHash = ComputeSha256Hash(token);

--- a/lighthouse-back/lighthouse-back/src/Services/Security/SecurityStampCache.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/Security/SecurityStampCache.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Lighthouse.Services.Security;
+
+/// <summary>
+/// Cached snapshot of the per-user security state checked on every authenticated request.
+/// </summary>
+public record UserSecurityInfo(string SecurityStamp, bool IsEnabled);
+
+/// <summary>
+/// Helpers for the security-stamp cache. The access-token validation path reads the
+/// current stamp / enabled flag from here (short TTL) to avoid a DB hit on every request;
+/// mutation paths (password change, disable, role change) invalidate the entry so the
+/// change takes effect immediately rather than after the TTL.
+/// </summary>
+public static class SecurityStampCache
+{
+    public static readonly TimeSpan Ttl = TimeSpan.FromSeconds(30);
+
+    public static string Key(int userId) => $"sec-stamp:{userId}";
+
+    public static void Invalidate(IMemoryCache cache, int userId) => cache.Remove(Key(userId));
+}

--- a/lighthouse-back/lighthouse-back/src/Services/UserService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/UserService.cs
@@ -2,8 +2,10 @@ using Lighthouse.Data;
 using Lighthouse.DTOs;
 using Lighthouse.Extensions;
 using Lighthouse.Models;
+using Lighthouse.Services.Security;
 using DockerComposeManager.Services.Security;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Lighthouse.Services;
 
@@ -32,17 +34,20 @@ public class UserService : IUserService
     private readonly ILogger<UserService> _logger;
     private readonly IAuditService _auditService;
     private readonly IPasswordHasher _passwordHasher;
+    private readonly IMemoryCache _cache;
 
     public UserService(
         AppDbContext context,
         ILogger<UserService> logger,
         IAuditService auditService,
-        IPasswordHasher passwordHasher)
+        IPasswordHasher passwordHasher,
+        IMemoryCache cache)
     {
         _context = context;
         _logger = logger;
         _auditService = auditService;
         _passwordHasher = passwordHasher;
+        _cache = cache;
     }
 
     public async Task<List<UserDto>> GetAllUsersAsync()
@@ -225,6 +230,9 @@ public class UserService : IUserService
             throw new InvalidOperationException($"User with ID {id} not found");
 
         var changes = new List<string>();
+        // Tracks whether the change must invalidate outstanding access tokens
+        // (role/disable/password). When set, the security stamp is rotated below.
+        var securityChanged = false;
 
         // Update username if provided
         if (request.Username != null && request.Username != user.Username)
@@ -247,6 +255,7 @@ public class UserService : IUserService
 
             changes.Add($"Role changed from '{user.Role?.Name}' to '{newRole.Name}'");
             user.RoleId = newRole.Id;
+            securityChanged = true; // role is embedded in the access token
         }
 
         // Update email if provided
@@ -280,6 +289,7 @@ public class UserService : IUserService
                 var sessions = await _context.Sessions.Where(s => s.UserId == id).ToListAsync();
                 _context.Sessions.RemoveRange(sessions);
                 changes.Add("All sessions invalidated");
+                securityChanged = true;
             }
         }
 
@@ -294,6 +304,7 @@ public class UserService : IUserService
             var sessions = await _context.Sessions.Where(s => s.UserId == id).ToListAsync();
             _context.Sessions.RemoveRange(sessions);
             changes.Add("All sessions invalidated due to password change");
+            securityChanged = true;
         }
 
         // Update mustChangePassword flag if provided (after password update so admin can set both)
@@ -327,6 +338,14 @@ public class UserService : IUserService
             }
 
             changes.Add($"Permissions updated ({request.Permissions.Count} permissions set)");
+        }
+
+        // Rotate the security stamp when the security context changed so all outstanding
+        // access tokens are rejected on their next request.
+        if (securityChanged)
+        {
+            user.SecurityStamp = Guid.NewGuid().ToString("N");
+            SecurityStampCache.Invalidate(_cache, user.Id);
         }
 
         await _context.SaveChangesAsync();
@@ -461,6 +480,10 @@ public class UserService : IUserService
         }
 
         user.IsEnabled = false;
+
+        // Rotate the security stamp so existing access tokens are rejected immediately.
+        user.SecurityStamp = Guid.NewGuid().ToString("N");
+        SecurityStampCache.Invalidate(_cache, user.Id);
 
         // Invalidate all sessions
         var sessions = await _context.Sessions.Where(s => s.UserId == id).ToListAsync();


### PR DESCRIPTION
Derniers items sécurité de la review. Approches validées avec toi : **1.10** table famille + reuse detection (+ hash au repos), **1.11** TTL court + SecurityStamp.

## 1.10 — Détection réutilisation refresh token

- Refresh tokens **hashés en DB** (SHA-256) ; le token brut ne vit que dans le cookie HttpOnly → une fuite DB n'expose aucun token utilisable.
- Chaque login démarre une **famille** (`FamilyId`) ; la rotation reste dans la famille et consomme l'ancien token (`IsUsed`). Présenter un token déjà consommé/révoqué = vol → **révocation de toute la famille** (`RevokedAt`), déconnexion attaquant + victime. Le logout révoque aussi la famille.
- Sessions périmées/révoquées purgées par le cleanup background service.

## 1.11 — Révocation access token (security stamp)

- `SecurityStamp` par user, embarqué en claim `sstamp`, **vérifié à chaque requête** (`OnTokenValidated`), caché ~30s pour éviter un hit DB/req. Roté (+ cache invalidé) sur : changement/reset mot de passe, disable, changement de rôle → tokens rejetés quasi-instantanément. Rejette aussi les tokens de users désactivés/supprimés.
- Durée de vie access token : **60 → 15 min**.

## Migration

Ajoute `Users.SecurityStamp` et `Sessions.{FamilyId, IsUsed, RevokedAt}`.
⚠️ **Re-login unique au déploiement** : les sessions/tokens existants deviennent invalides (changement de hash). Reuse detection stricte → une réponse de refresh perdue force aussi un re-login (tradeoff assumé).

## Tests & vérification

- **+5** tests AuthService : hash au repos, rotation, reuse→révocation famille, logout, rotation stamp. Backend **383/383**.
- Vérifié end-to-end (curl) :
  - reuse (replay ancien cookie) → **401** + famille révoquée (token roté aussi → 401)
  - claim `sstamp` présent, `/me` 200
  - changement mot de passe → ancien access token → **401**, nouveau → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)