### PR TITLE
perf: Batch A — reliability + quick wins (WAL, startup cleanup, SSE, JWT dedup)

### DIFF
--- a/lighthouse-back/lighthouse-back/Program.cs
+++ b/lighthouse-back/lighthouse-back/Program.cs
@@ -91,7 +91,10 @@ catch (Exception ex)
 
 // Add Database Context
 string connectionString = builder.Configuration["Database:ConnectionString"] ?? "Data Source=Data/app.db";
-builder.Services.AddDbContext<AppDbContext>(options =>options.UseSqlite(connectionString));
+builder.Services.AddDbContext<AppDbContext>(options => options
+    .UseSqlite(connectionString)
+    // Enable WAL + busy_timeout + FK enforcement on every connection.
+    .AddInterceptors(new Lighthouse.Data.SqliteConnectionInterceptor()));
 
 // Configure JWT Authentication
 string jwtSecret = builder.Configuration["Jwt:Secret"] ?? string.Empty;

--- a/lighthouse-back/lighthouse-back/src/BackgroundServices/CleanupBackgroundService.cs
+++ b/lighthouse-back/lighthouse-back/src/BackgroundServices/CleanupBackgroundService.cs
@@ -25,62 +25,75 @@ public class CleanupBackgroundService : BackgroundService
         _logger.LogInformation("Token Cleanup Background Service starting. Cleanup interval: {Hours} hours",
             _options.CleanupIntervalHours);
 
+        // Short settle delay so the first cleanup doesn't compete with startup work,
+        // then run immediately (a fresh restart no longer waits a full interval).
+        try
+        {
+            await Task.Delay(TimeSpan.FromSeconds(15), stoppingToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
         while (!stoppingToken.IsCancellationRequested)
         {
             try
             {
-                await Task.Delay(TimeSpan.FromHours(_options.CleanupIntervalHours), stoppingToken);
-
-                if (stoppingToken.IsCancellationRequested)
-                    break;
-
-                _logger.LogInformation("Running password reset token cleanup...");
-
-                // Create a scope to resolve the scoped service
-                using IServiceScope scope = _serviceProvider.CreateScope();
-                IPasswordResetService passwordResetService = scope.ServiceProvider.GetRequiredService<IPasswordResetService>();
-
-                var deletedCount = await passwordResetService.CleanupExpiredTokensAsync();
-
-                if (deletedCount > 0)
-                {
-                    _logger.LogInformation("Token cleanup completed. Deleted {Count} expired tokens", deletedCount);
-                }
-                else
-                {
-                    _logger.LogDebug("Token cleanup completed. No expired tokens to delete");
-                }
-
-                // Cleanup old operations (older than 7 days)
-                OperationService operationService = scope.ServiceProvider.GetRequiredService<OperationService>();
-                var operationDeletedCount = await operationService.CleanupOldOperationsAsync(
-                    DateTime.UtcNow.AddDays(-7));
-                if (operationDeletedCount > 0)
-                {
-                    _logger.LogInformation("Operation cleanup completed. Deleted {Count} old operations", operationDeletedCount);
-                }
-
-                // Cleanup expired / long-revoked refresh sessions
-                AuthService authService = scope.ServiceProvider.GetRequiredService<AuthService>();
-                var sessionDeletedCount = await authService.CleanupExpiredSessionsAsync();
-                if (sessionDeletedCount > 0)
-                {
-                    _logger.LogInformation("Session cleanup completed. Deleted {Count} stale sessions", sessionDeletedCount);
-                }
+                await RunCleanupAsync();
             }
             catch (OperationCanceledException)
             {
-                // Expected when cancellation is requested
-                _logger.LogInformation("Token Cleanup Background Service is stopping");
                 break;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error occurred during token cleanup");
+                _logger.LogError(ex, "Error occurred during cleanup");
                 // Continue running despite errors
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromHours(_options.CleanupIntervalHours), stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
             }
         }
 
         _logger.LogInformation("Token Cleanup Background Service stopped");
+    }
+
+    private async Task RunCleanupAsync()
+    {
+        _logger.LogInformation("Running scheduled cleanup...");
+
+        // Create a scope to resolve the scoped services
+        using IServiceScope scope = _serviceProvider.CreateScope();
+
+        IPasswordResetService passwordResetService = scope.ServiceProvider.GetRequiredService<IPasswordResetService>();
+        var deletedCount = await passwordResetService.CleanupExpiredTokensAsync();
+        if (deletedCount > 0)
+        {
+            _logger.LogInformation("Token cleanup completed. Deleted {Count} expired tokens", deletedCount);
+        }
+
+        // Cleanup old operations (older than 7 days)
+        OperationService operationService = scope.ServiceProvider.GetRequiredService<OperationService>();
+        var operationDeletedCount = await operationService.CleanupOldOperationsAsync(
+            DateTime.UtcNow.AddDays(-7));
+        if (operationDeletedCount > 0)
+        {
+            _logger.LogInformation("Operation cleanup completed. Deleted {Count} old operations", operationDeletedCount);
+        }
+
+        // Cleanup expired / long-revoked refresh sessions
+        AuthService authService = scope.ServiceProvider.GetRequiredService<AuthService>();
+        var sessionDeletedCount = await authService.CleanupExpiredSessionsAsync();
+        if (sessionDeletedCount > 0)
+        {
+            _logger.LogInformation("Session cleanup completed. Deleted {Count} stale sessions", sessionDeletedCount);
+        }
     }
 }

--- a/lighthouse-back/lighthouse-back/src/Data/SqliteConnectionInterceptor.cs
+++ b/lighthouse-back/lighthouse-back/src/Data/SqliteConnectionInterceptor.cs
@@ -1,0 +1,39 @@
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Lighthouse.Data;
+
+/// <summary>
+/// Applies per-connection SQLite PRAGMAs whenever a connection is opened:
+/// <list type="bullet">
+/// <item>WAL journal mode — readers no longer block the single writer, drastically
+/// reducing "database is locked" errors under concurrent writes (SSE, audit, operations).</item>
+/// <item>busy_timeout — a writer waits (instead of failing immediately) when the DB is
+/// momentarily locked.</item>
+/// <item>foreign_keys — enforce FK constraints (off by default in SQLite).</item>
+/// </list>
+/// busy_timeout is per-connection so it must be set on every open (WAL is persistent but
+/// re-asserting it is harmless).
+/// </summary>
+public sealed class SqliteConnectionInterceptor : DbConnectionInterceptor
+{
+    private const string Pragmas =
+        "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA foreign_keys=ON;";
+
+    public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
+    {
+        using DbCommand command = connection.CreateCommand();
+        command.CommandText = Pragmas;
+        command.ExecuteNonQuery();
+        base.ConnectionOpened(connection, eventData);
+    }
+
+    public override async Task ConnectionOpenedAsync(
+        DbConnection connection, ConnectionEndEventData eventData, CancellationToken cancellationToken = default)
+    {
+        await using DbCommand command = connection.CreateCommand();
+        command.CommandText = Pragmas;
+        await command.ExecuteNonQueryAsync(cancellationToken);
+        await base.ConnectionOpenedAsync(connection, eventData, cancellationToken);
+    }
+}

--- a/lighthouse-front/src/lib/api/client.ts
+++ b/lighthouse-front/src/lib/api/client.ts
@@ -3,6 +3,7 @@ import type { InternalAxiosRequestConfig } from 'axios';
 import * as auth from '$lib/stores/auth.svelte';
 import { reconnectSSEWithNewToken } from '$lib/stores/sse.svelte';
 import { refreshAccessToken } from '$lib/api/tokenRefresh';
+import { isNearExpiration } from '$lib/utils/jwt';
 import { browser } from '$app/environment';
 
 // Extend InternalAxiosRequestConfig to include _retry property for token refresh
@@ -25,19 +26,11 @@ const getApiUrl = () => {
 
 const API_URL = getApiUrl();
 
-/**
- * Check if a JWT token is near expiration (within 10 minutes).
- */
+// Refresh proactively when less than 10 minutes remain on the access token.
+const PROACTIVE_REFRESH_MARGIN_MS = 10 * 60 * 1000;
+
 function isTokenNearExpiration(token: string): boolean {
-  try {
-    const payload = JSON.parse(atob(token.split('.')[1]));
-    const expiresAt = payload.exp * 1000;
-    const timeLeft = expiresAt - Date.now();
-    // Refresh if less than 10 minutes remaining
-    return timeLeft < 10 * 60 * 1000;
-  } catch {
-    return true; // If parsing fails, consider it expired
-  }
+  return isNearExpiration(token, PROACTIVE_REFRESH_MARGIN_MS);
 }
 
 /**

--- a/lighthouse-front/src/lib/stores/auth.svelte.ts
+++ b/lighthouse-front/src/lib/stores/auth.svelte.ts
@@ -1,5 +1,6 @@
 import { browser } from '$app/environment';
 import type { User } from '$lib/types';
+import { getRoleFromToken } from '$lib/utils/jwt';
 
 // Svelte 5 pattern: export state object with properties (not individual $state variables)
 //
@@ -15,8 +16,13 @@ export const auth = $state({
 export const isAuthenticated = {
   get current() { return !!auth.accessToken; }
 };
+// Prefer the loaded user's role; before /me resolves (e.g. right after a reload) fall
+// back to the role embedded in the access token so admin UI does not flicker.
 export const isAdmin = {
-  get current() { return auth.user?.role?.toLowerCase() === 'admin'; }
+  get current() {
+    const role = auth.user?.role ?? getRoleFromToken(auth.accessToken);
+    return role?.toLowerCase() === 'admin';
+  }
 };
 
 // Actions

--- a/lighthouse-front/src/lib/stores/sse.svelte.ts
+++ b/lighthouse-front/src/lib/stores/sse.svelte.ts
@@ -3,6 +3,7 @@ import type { OperationUpdateEvent } from '$lib/types';
 import type { MaintenanceModeNotification, UpdateProgressEvent, ProjectUpdatesCheckedEvent, ContainerUpdatesCheckedEvent } from '$lib/types/update';
 import { logger } from '$lib/utils/logger';
 import { refreshAccessToken } from '$lib/api/tokenRefresh';
+import { isExpired } from '$lib/utils/jwt';
 
 // Types for SSE events
 export interface ContainerStateChangedEvent {
@@ -67,7 +68,8 @@ let isInitializing = false;
 let heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
 let lastEventTime = 0;
 
-const HEARTBEAT_TIMEOUT_MS = 900_000; // Consider disconnected if no event in 15 minutes
+// Server sends a heartbeat every 30s; treat 3 consecutive misses (~90s) as a dead link.
+const HEARTBEAT_TIMEOUT_MS = 90_000;
 const MAX_RECONNECT_ATTEMPTS = 10; // Max consecutive reconnection attempts before giving up
 
 const getApiUrl = () => {
@@ -80,17 +82,9 @@ const getApiUrl = () => {
   return '';
 };
 
-/**
- * Check if a JWT token is expired (with 60s safety margin).
- */
+// Treat the token as expired 60s early to avoid connecting with an about-to-expire token.
 function isTokenExpired(token: string): boolean {
-  try {
-    const payload = JSON.parse(atob(token.split('.')[1]));
-    // Add 60 second margin to avoid race conditions
-    return (payload.exp * 1000) < (Date.now() + 60_000);
-  } catch {
-    return true;
-  }
+  return isExpired(token, 60_000);
 }
 
 /**
@@ -125,7 +119,7 @@ function resetHeartbeatTimer() {
 
   heartbeatTimer = setTimeout(() => {
     if (sseState.connectionStatus === 'connected') {
-      logger.warn('[SSE Store] No events received for 15 minutes, reconnecting...');
+      logger.warn('[SSE Store] No events received for 90s, reconnecting...');
       reconnect();
     }
   }, HEARTBEAT_TIMEOUT_MS);

--- a/lighthouse-front/src/lib/utils/jwt.test.ts
+++ b/lighthouse-front/src/lib/utils/jwt.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { parseJwt, isExpired, isNearExpiration, getRoleFromToken } from './jwt';
+
+// Build a fake unsigned JWT with the given payload (base64url, no padding).
+function makeToken(payload: Record<string, unknown>): string {
+  const b64url = (obj: unknown) =>
+    Buffer.from(JSON.stringify(obj))
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+  return `${b64url({ alg: 'HS256', typ: 'JWT' })}.${b64url(payload)}.sig`;
+}
+
+const ROLE_URI = 'http://schemas.microsoft.com/ws/2008/06/identity/claims/role';
+
+describe('jwt utils', () => {
+  it('parses a valid payload', () => {
+    const token = makeToken({ sub: '1', exp: 123 });
+    expect(parseJwt(token)).toMatchObject({ sub: '1', exp: 123 });
+  });
+
+  it('returns null on malformed / empty tokens', () => {
+    expect(parseJwt(null)).toBeNull();
+    expect(parseJwt('')).toBeNull();
+    expect(parseJwt('not-a-jwt')).toBeNull();
+    expect(parseJwt('a.b')).not.toBeUndefined(); // b is not valid base64 json -> null
+    expect(parseJwt('a.%%%.c')).toBeNull();
+  });
+
+  it('detects expiry with margin', () => {
+    const future = makeToken({ exp: Math.floor(Date.now() / 1000) + 3600 });
+    const past = makeToken({ exp: Math.floor(Date.now() / 1000) - 10 });
+    expect(isExpired(future)).toBe(false);
+    expect(isExpired(past)).toBe(true);
+    // 2h margin makes a token expiring in 1h count as expired
+    expect(isExpired(future, 2 * 3600 * 1000)).toBe(true);
+    // no exp claim -> treated as expired
+    expect(isExpired(makeToken({ sub: '1' }))).toBe(true);
+  });
+
+  it('detects near expiration', () => {
+    const in5min = makeToken({ exp: Math.floor(Date.now() / 1000) + 5 * 60 });
+    expect(isNearExpiration(in5min, 10 * 60 * 1000)).toBe(true);
+    expect(isNearExpiration(in5min, 60 * 1000)).toBe(false);
+  });
+
+  it('reads role from short and .NET URI claim', () => {
+    expect(getRoleFromToken(makeToken({ role: 'admin' }))).toBe('admin');
+    expect(getRoleFromToken(makeToken({ [ROLE_URI]: 'user' }))).toBe('user');
+    expect(getRoleFromToken(makeToken({ sub: '1' }))).toBeNull();
+    expect(getRoleFromToken(null)).toBeNull();
+  });
+});

--- a/lighthouse-front/src/lib/utils/jwt.ts
+++ b/lighthouse-front/src/lib/utils/jwt.ts
@@ -1,0 +1,47 @@
+// Small helpers for reading the (unverified) client-side JWT access token. These never
+// validate the signature — that is the server's job — they only read claims the client
+// legitimately needs (expiry for proactive refresh, role for immediate UI gating).
+
+export interface JwtPayload {
+  exp?: number;
+  [key: string]: unknown;
+}
+
+/** .NET emits the role claim under this URI unless claim mapping is customised. */
+const ROLE_CLAIM_URI = 'http://schemas.microsoft.com/ws/2008/06/identity/claims/role';
+
+/** Decode a JWT payload (base64url). Returns null on any malformed input. */
+export function parseJwt(token: string | null | undefined): JwtPayload | null {
+  if (!token) return null;
+  try {
+    const part = token.split('.')[1];
+    if (!part) return null;
+    const base64 = part.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
+    return JSON.parse(atob(padded)) as JwtPayload;
+  } catch {
+    return null;
+  }
+}
+
+/** True if the token is expired (or unparseable), with an optional safety margin in ms. */
+export function isExpired(token: string, marginMs = 0): boolean {
+  const payload = parseJwt(token);
+  if (!payload?.exp) return true;
+  return payload.exp * 1000 < Date.now() + marginMs;
+}
+
+/** True if the token expires within `withinMs` (or is unparseable). */
+export function isNearExpiration(token: string, withinMs: number): boolean {
+  const payload = parseJwt(token);
+  if (!payload?.exp) return true;
+  return payload.exp * 1000 - Date.now() < withinMs;
+}
+
+/** Read the role claim from an access token, or null. */
+export function getRoleFromToken(token: string | null | undefined): string | null {
+  const payload = parseJwt(token);
+  if (!payload) return null;
+  const role = (payload['role'] ?? payload[ROLE_CLAIM_URI]) as string | undefined;
+  return role ?? null;
+}


### PR DESCRIPTION
Section 2/3 de la review — **Batch A** (fiabilité + quick wins, faible risque).

## Fixes

| # | Fix |
|---|-----|
| 3.2 | **SQLite WAL + busy_timeout** — un `DbConnectionInterceptor` applique `journal_mode=WAL`, `busy_timeout=5000`, `foreign_keys=ON` à chaque ouverture. WAL : les lecteurs ne bloquent plus le writer unique → moins de `database is locked` sous écritures concurrentes (SSE + audit + operations). **Vérifié runtime** (`-wal`/`-shm` présents). |
| 2.10 | **Cleanup au démarrage** — le service de cleanup tourne une fois peu après le boot au lieu d'attendre un intervalle complet ; corps extrait dans `RunCleanupAsync`. |
| 2.6 | **SSE heartbeat** — détection de lien mort ramenée de 15 min à **90s** (heartbeat serveur toutes les 30s). |
| 2.7 | **Dédup décodage JWT** — `client.ts` + `sse.svelte` dupliquaient un `atob` maison → extrait dans `lib/utils/jwt` (base64url-safe, testé). |
| 3.8 | **`isAdmin` sans flicker** — fallback sur le rôle du token tant que `/me` n'a pas répondu → plus de clignotement de l'UI admin au reload. |

**2.8** (logs SSE verbeux) : aucun changement nécessaire — ils passent par `logger.log`, déjà no-op hors dev.

## Checks

- Backend **383/383** · Frontend **36/36** (+5 jwt) · `svelte-check` 0 err · builds OK.
- WAL confirmé au runtime.

## Suite

Batch B (perf permissions : N+1, ListProjects, sargable), puis C (refacto `ComposeController` avec tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)