### PR TITLE
refactor(compose): C2 — IOperationService + dedup lifecycle endpoints

### DIFF
--- a/dev-setup/sample-compose-files/demo-compose.yml
+++ b/dev-setup/sample-compose-files/demo-compose.yml
@@ -3,9 +3,11 @@
 # folder. Drop your own .yml/.yaml files here to experiment.
 name: demo-stack
 services:
-  whoami:
-    image: traefik/whoami:latest
-    container_name: demo-whoami
+  nginx:
+    image: nginx
+    container_name: nginx
     ports:
-      - "8088:80"
+      - "15645:80"
+    environment:
+    - NGINX_PORT=80
     restart: unless-stopped

--- a/lighthouse-back/lighthouse-back.Tests/Controllers/ComposeControllerTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Controllers/ComposeControllerTests.cs
@@ -1,0 +1,134 @@
+using Lighthouse.Controllers;
+using Lighthouse.DTOs;
+using Lighthouse.Models;
+using Lighthouse.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System.Security.Claims;
+
+namespace Lighthouse.Tests.Controllers;
+
+public class ComposeControllerTests
+{
+    private readonly Mock<IComposeDiscoveryService> _discovery = new();
+    private readonly Mock<IComposeOperationService> _composeOp = new();
+    private readonly Mock<IOperationService> _legacyOp = new();
+    private readonly Mock<IAuditService> _audit = new();
+    private readonly Mock<IPermissionService> _permission = new();
+    private readonly Mock<IProjectMatchingService> _matching = new();
+    private readonly Mock<IComposeFileCacheService> _fileCache = new();
+    private readonly Mock<IImageUpdateCacheService> _imageCache = new();
+    private readonly Mock<ISelfFilterService> _selfFilter = new();
+
+    private ComposeController Build(bool authenticated = true)
+    {
+        // Sensible permissive defaults; individual tests override.
+        _selfFilter.Setup(s => s.IsSelfProjectAsync(It.IsAny<string>())).ReturnsAsync(false);
+        _permission.Setup(p => p.HasPermissionAsync(
+                It.IsAny<int>(), It.IsAny<ResourceType>(), It.IsAny<string>(), It.IsAny<PermissionFlags>()))
+            .ReturnsAsync(true);
+        _legacyOp.Setup(o => o.CreateOperationAsync(
+                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(new Operation { OperationId = "op1", Type = OperationType.ComposeUp, Status = OperationStatus.Pending });
+
+        var controller = new ComposeController(
+            _discovery.Object, _composeOp.Object, _legacyOp.Object, _audit.Object,
+            _permission.Object, NullLogger<ComposeController>.Instance, _matching.Object,
+            _fileCache.Object, _imageCache.Object, _selfFilter.Object);
+
+        // Set the current user on the controller context (BaseController reads claims).
+        var identity = authenticated
+            ? new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "1") }, "test")
+            : new ClaimsIdentity();
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+        return controller;
+    }
+
+    private static int? StatusOf(ActionResult<ApiResponse<ComposeOperationResponse>> result) =>
+        (result.Result as ObjectResult)?.StatusCode;
+
+    private static ComposeProjectDto Project(string name, bool hasComposeFile) =>
+        new(name, $"/compose/{name}", "down", new List<ComposeServiceDto>(), new List<string>(), null,
+            ComposeFilePath: hasComposeFile ? $"/compose/{name}/docker-compose.yml" : null,
+            HasComposeFile: hasComposeFile);
+
+    [Fact]
+    public async Task UpProject_SelfProject_Returns403()
+    {
+        var controller = Build();
+        _selfFilter.Setup(s => s.IsSelfProjectAsync("self")).ReturnsAsync(true);
+
+        var result = await controller.UpProject("self", new ComposeUpRequest());
+
+        StatusOf(result).Should().Be(403);
+    }
+
+    [Fact]
+    public async Task UpProject_NoPermission_Returns403()
+    {
+        var controller = Build();
+        _permission.Setup(p => p.HasPermissionAsync(
+                It.IsAny<int>(), ResourceType.ComposeProject, "proj", PermissionFlags.Start))
+            .ReturnsAsync(false);
+
+        var result = await controller.UpProject("proj", new ComposeUpRequest());
+
+        StatusOf(result).Should().Be(403);
+    }
+
+    [Fact]
+    public async Task UpProject_Unauthenticated_Returns401()
+    {
+        var controller = Build(authenticated: false);
+
+        var result = await controller.UpProject("proj", new ComposeUpRequest());
+
+        StatusOf(result).Should().Be(401);
+    }
+
+    [Fact]
+    public async Task UpProject_NoComposeFile_Returns400()
+    {
+        var controller = Build();
+        _matching.Setup(m => m.GetUnifiedProjectListAsync(1))
+            .ReturnsAsync(new List<ComposeProjectDto> { Project("proj", hasComposeFile: false) });
+
+        var result = await controller.UpProject("proj", new ComposeUpRequest());
+
+        StatusOf(result).Should().Be(400);
+    }
+
+    [Fact]
+    public async Task UpProject_Success_Returns200()
+    {
+        var controller = Build();
+        _matching.Setup(m => m.GetUnifiedProjectListAsync(1))
+            .ReturnsAsync(new List<ComposeProjectDto> { Project("proj", hasComposeFile: true) });
+        _composeOp.Setup(o => o.UpAsync("proj", It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OperationResult { Success = true, Message = "started", Output = "", Error = null });
+
+        var result = await controller.UpProject("proj", new ComposeUpRequest());
+
+        (result.Result as OkObjectResult)?.StatusCode.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task DownProject_NoPermission_Returns403()
+    {
+        var controller = Build();
+        _permission.Setup(p => p.HasPermissionAsync(
+                It.IsAny<int>(), ResourceType.ComposeProject, "proj", PermissionFlags.Stop))
+            .ReturnsAsync(false);
+
+        var result = await controller.DownProject("proj", new ComposeDownRequest());
+
+        StatusOf(result).Should().Be(403);
+    }
+}

--- a/lighthouse-back/lighthouse-back/src/BackgroundServices/CleanupBackgroundService.cs
+++ b/lighthouse-back/lighthouse-back/src/BackgroundServices/CleanupBackgroundService.cs
@@ -80,7 +80,7 @@ public class CleanupBackgroundService : BackgroundService
         }
 
         // Cleanup old operations (older than 7 days)
-        OperationService operationService = scope.ServiceProvider.GetRequiredService<OperationService>();
+        IOperationService operationService = scope.ServiceProvider.GetRequiredService<IOperationService>();
         var operationDeletedCount = await operationService.CleanupOldOperationsAsync(
             DateTime.UtcNow.AddDays(-7));
         if (operationDeletedCount > 0)

--- a/lighthouse-back/lighthouse-back/src/Controllers/ComposeController.cs
+++ b/lighthouse-back/lighthouse-back/src/Controllers/ComposeController.cs
@@ -18,7 +18,7 @@ public class ComposeController : BaseController
 {
     private readonly IComposeDiscoveryService _discoveryService;
     private readonly IComposeOperationService _operationService;
-    private readonly OperationService _legacyOperationService;
+    private readonly IOperationService _legacyOperationService;
     private readonly IAuditService _auditService;
     private readonly IPermissionService _permissionService;
     private readonly ILogger<ComposeController> _logger;
@@ -30,7 +30,7 @@ public class ComposeController : BaseController
     public ComposeController(
         IComposeDiscoveryService discoveryService,
         IComposeOperationService operationService,
-        OperationService legacyOperationService,
+        IOperationService legacyOperationService,
         IAuditService auditService,
         IPermissionService permissionService,
         ILogger<ComposeController> logger,
@@ -125,38 +125,11 @@ public class ComposeController : BaseController
         {
             projectName = Uri.UnescapeDataString(projectName);
 
-            // Self-protection
-            if (await _selfFilterService.IsSelfProjectAsync(projectName))
-            {
-                return StatusCode(403, ApiResponse.Fail<ComposeOperationResponse>(
-                    "This project belongs to the application itself and cannot be modified",
-                    "SELF_PROJECT_PROTECTED"));
-            }
+            var (userId, error) = await AuthorizeProjectOperationAsync(projectName, PermissionFlags.Start, "start");
+            if (error != null) return error;
 
-            // Check permission
-            int? userId = GetCurrentUserId();
-            if (!userId.HasValue)
-            {
-                return Unauthorized(ApiResponse.Fail<ComposeOperationResponse>("User not authenticated"));
-            }
-
-            bool hasPermission = await _permissionService.HasPermissionAsync(
-                userId.Value,
-                ResourceType.ComposeProject,
-                projectName,
-                PermissionFlags.Start
-            );
-
-            if (!hasPermission)
-            {
-                return StatusCode(403, ApiResponse.Fail<ComposeOperationResponse>(
-                    "You don't have permission to start this compose project",
-                    "PERMISSION_DENIED"
-                ));
-            }
-
-            // Get project info to check if compose file exists
-            List<ComposeProjectDto> projects = await _projectMatchingService.GetUnifiedProjectListAsync(userId.Value);
+            // 'up' requires a compose file, so resolve the project first.
+            List<ComposeProjectDto> projects = await _projectMatchingService.GetUnifiedProjectListAsync(userId);
             ComposeProjectDto? project = projects.FirstOrDefault(p => p.Name.Equals(projectName, StringComparison.OrdinalIgnoreCase));
 
             if (project == null)
@@ -164,7 +137,6 @@ public class ComposeController : BaseController
                 return NotFound(ApiResponse.Fail<ComposeOperationResponse>("Project not found"));
             }
 
-            // 'up' command requires compose file
             if (!project.HasComposeFile)
             {
                 return BadRequest(ApiResponse.Fail<ComposeOperationResponse>(
@@ -174,56 +146,13 @@ public class ComposeController : BaseController
                 ));
             }
 
-            // Create operation tracking
-            var operation = await _legacyOperationService.CreateOperationAsync(
-                OperationType.ComposeUp, userId.Value, projectPath: project.Path, projectName: projectName);
-            await _legacyOperationService.UpdateOperationStatusAsync(
-                operation.OperationId, OperationStatus.Running);
-
-            // Execute operation using new service
             OperationResult result = await _operationService.UpAsync(
-                projectName,
-                project.ComposeFilePath,
-                request?.Build ?? false
-            );
+                projectName, project.ComposeFilePath, request?.Build ?? false);
 
-            // Update operation with result — store actual docker compose output
-            string? logs = ComposeOutputHelper.BuildLogs(result);
-            if (!string.IsNullOrEmpty(logs))
-                await _legacyOperationService.AppendLogsAsync(operation.OperationId, logs);
-            await _legacyOperationService.UpdateOperationStatusAsync(
-                operation.OperationId,
-                result.Success ? OperationStatus.Completed : OperationStatus.Failed,
-                progress: 100,
-                errorMessage: result.Success ? null : result.Error);
-
-            await _auditService.LogActionAsync(
-                userId.Value,
-                AuditActions.ComposeUp,
-                GetUserIpAddress(),
-                $"Started project: {projectName}",
-                resourceType: "compose_project",
-                resourceId: projectName
-            );
-
-            if (result.Success)
-            {
-                _logger.LogInformation("Project {ProjectName} started successfully by user {UserId}", projectName, userId.Value);
-            }
-            else
-            {
-                _logger.LogWarning("Failed to start project {ProjectName}: {Error}", projectName, result.Error);
-            }
-
-            ComposeOperationResponse response = new(
-                operation.OperationId,
-                result.Success ? OperationStatus.Completed : OperationStatus.Failed,
-                result.Message
-            );
-
-            return result.Success
-                ? Ok(ApiResponse.Ok(response))
-                : BadRequest(ApiResponse.Fail<ComposeOperationResponse>(result.Message, "OPERATION_FAILED"));
+            return await FinalizeOperationAsync(
+                OperationType.ComposeUp, userId, projectName, project.Path,
+                AuditActions.ComposeUp, $"Started project: {projectName}",
+                result, ComposeOutputHelper.BuildLogs(result));
         }
         catch (Exception ex)
         {
@@ -244,86 +173,16 @@ public class ComposeController : BaseController
         {
             projectName = Uri.UnescapeDataString(projectName);
 
-            // Self-protection
-            if (await _selfFilterService.IsSelfProjectAsync(projectName))
-            {
-                return StatusCode(403, ApiResponse.Fail<ComposeOperationResponse>(
-                    "This project belongs to the application itself and cannot be modified",
-                    "SELF_PROJECT_PROTECTED"));
-            }
+            var (userId, error) = await AuthorizeProjectOperationAsync(projectName, PermissionFlags.Stop, "stop");
+            if (error != null) return error;
 
-            // Check permission
-            int? userId = GetCurrentUserId();
-            if (!userId.HasValue)
-            {
-                return Unauthorized(ApiResponse.Fail<ComposeOperationResponse>("User not authenticated"));
-            }
+            string? projectPath = await ResolveProjectPathAsync(projectName, userId);
+            OperationResult result = await _operationService.DownAsync(projectName, request?.RemoveVolumes ?? false);
 
-            bool hasPermission = await _permissionService.HasPermissionAsync(
-                userId.Value,
-                ResourceType.ComposeProject,
-                projectName,
-                PermissionFlags.Stop
-            );
-
-            if (!hasPermission)
-            {
-                return StatusCode(403, ApiResponse.Fail<ComposeOperationResponse>(
-                    "You don't have permission to stop this compose project",
-                    "PERMISSION_DENIED"
-                ));
-            }
-
-            // Create operation tracking
-            string? projectPath = await ResolveProjectPathAsync(projectName, userId.Value);
-            var operation = await _legacyOperationService.CreateOperationAsync(
-                OperationType.ComposeDown, userId.Value, projectPath: projectPath, projectName: projectName);
-            await _legacyOperationService.UpdateOperationStatusAsync(
-                operation.OperationId, OperationStatus.Running);
-
-            // Execute operation using new service
-            OperationResult result = await _operationService.DownAsync(
-                projectName,
-                request?.RemoveVolumes ?? false
-            );
-
-            // Update operation with result — store actual docker compose output
-            string? logs = ComposeOutputHelper.BuildLogs(result);
-            if (!string.IsNullOrEmpty(logs))
-                await _legacyOperationService.AppendLogsAsync(operation.OperationId, logs);
-            await _legacyOperationService.UpdateOperationStatusAsync(
-                operation.OperationId,
-                result.Success ? OperationStatus.Completed : OperationStatus.Failed,
-                progress: 100,
-                errorMessage: result.Success ? null : result.Error);
-
-            await _auditService.LogActionAsync(
-                userId.Value,
-                AuditActions.ComposeDown,
-                GetUserIpAddress(),
-                $"Stopped project: {projectName}",
-                resourceType: "compose_project",
-                resourceId: projectName
-            );
-
-            if (result.Success)
-            {
-                _logger.LogInformation("Project {ProjectName} stopped successfully by user {UserId}", projectName, userId.Value);
-            }
-            else
-            {
-                _logger.LogWarning("Failed to stop project {ProjectName}: {Error}", projectName, result.Error);
-            }
-
-            ComposeOperationResponse response = new(
-                operation.OperationId,
-                result.Success ? OperationStatus.Completed : OperationStatus.Failed,
-                result.Message
-            );
-
-            return result.Success
-                ? Ok(ApiResponse.Ok(response))
-                : BadRequest(ApiResponse.Fail<ComposeOperationResponse>(result.Message, "OPERATION_FAILED"));
+            return await FinalizeOperationAsync(
+                OperationType.ComposeDown, userId, projectName, projectPath,
+                AuditActions.ComposeDown, $"Stopped project: {projectName}",
+                result, ComposeOutputHelper.BuildLogs(result));
         }
         catch (Exception ex)
         {
@@ -745,6 +604,82 @@ volumes:
         }
     }
 
+    /// <summary>
+    /// Runs the guards shared by every project lifecycle action: self-protection,
+    /// authentication and permission. Returns the resolved user id on success, or an
+    /// error result to return directly.
+    /// </summary>
+    private async Task<(int UserId, ActionResult<ApiResponse<ComposeOperationResponse>>? Error)> AuthorizeProjectOperationAsync(
+        string projectName, PermissionFlags permission, string permissionVerb)
+    {
+        if (await _selfFilterService.IsSelfProjectAsync(projectName))
+        {
+            return (0, StatusCode(403, ApiResponse.Fail<ComposeOperationResponse>(
+                "This project belongs to the application itself and cannot be modified",
+                "SELF_PROJECT_PROTECTED")));
+        }
+
+        int? userId = GetCurrentUserId();
+        if (!userId.HasValue)
+        {
+            return (0, Unauthorized(ApiResponse.Fail<ComposeOperationResponse>("User not authenticated")));
+        }
+
+        bool hasPermission = await _permissionService.HasPermissionAsync(
+            userId.Value, ResourceType.ComposeProject, projectName, permission);
+        if (!hasPermission)
+        {
+            return (0, StatusCode(403, ApiResponse.Fail<ComposeOperationResponse>(
+                $"You don't have permission to {permissionVerb} this compose project",
+                "PERMISSION_DENIED")));
+        }
+
+        return (userId.Value, null);
+    }
+
+    /// <summary>
+    /// Records an operation for a completed project action (create + running + logs +
+    /// final status), writes the audit entry, and builds the HTTP response. Shared by all
+    /// lifecycle endpoints so the tracking/audit/response shape stays identical.
+    /// </summary>
+    private async Task<ActionResult<ApiResponse<ComposeOperationResponse>>> FinalizeOperationAsync(
+        string operationType, int userId, string projectName, string? projectPath,
+        string auditAction, string auditDetail, OperationResult result, string? logs)
+    {
+        Operation operation = await _legacyOperationService.CreateOperationAsync(
+            operationType, userId, projectPath: projectPath, projectName: projectName);
+        await _legacyOperationService.UpdateOperationStatusAsync(operation.OperationId, OperationStatus.Running);
+
+        if (!string.IsNullOrEmpty(logs))
+            await _legacyOperationService.AppendLogsAsync(operation.OperationId, logs);
+
+        await _legacyOperationService.UpdateOperationStatusAsync(
+            operation.OperationId,
+            result.Success ? OperationStatus.Completed : OperationStatus.Failed,
+            progress: 100,
+            errorMessage: result.Success ? null : result.Error);
+
+        await _auditService.LogActionAsync(
+            userId, auditAction, GetUserIpAddress(), auditDetail,
+            resourceType: "compose_project", resourceId: projectName);
+
+        if (result.Success)
+            _logger.LogInformation("Operation {OperationType} on project {ProjectName} succeeded (user {UserId})",
+                operationType, projectName, userId);
+        else
+            _logger.LogWarning("Operation {OperationType} on project {ProjectName} failed: {Error}",
+                operationType, projectName, result.Error);
+
+        ComposeOperationResponse response = new(
+            operation.OperationId,
+            result.Success ? OperationStatus.Completed : OperationStatus.Failed,
+            result.Message);
+
+        return result.Success
+            ? Ok(ApiResponse.Ok(response))
+            : BadRequest(ApiResponse.Fail<ComposeOperationResponse>(result.Message, "OPERATION_FAILED"));
+    }
+
     #region Helper Methods
 
     /// <summary>
@@ -757,70 +692,16 @@ volumes:
         {
             projectName = Uri.UnescapeDataString(projectName);
 
-            // Self-protection
-            if (await _selfFilterService.IsSelfProjectAsync(projectName))
-            {
-                return StatusCode(403, ApiResponse.Fail<ComposeOperationResponse>(
-                    "This project belongs to the application itself and cannot be modified",
-                    "SELF_PROJECT_PROTECTED"));
-            }
+            var (userId, error) = await AuthorizeProjectOperationAsync(projectName, PermissionFlags.Start, "start");
+            if (error != null) return error;
 
-            int? userId = GetCurrentUserId();
-            if (!userId.HasValue)
-            {
-                return Unauthorized(ApiResponse.Fail<ComposeOperationResponse>("User not authenticated"));
-            }
-
-            bool hasPermission = await _permissionService.HasPermissionAsync(
-                userId.Value,
-                ResourceType.ComposeProject,
-                projectName,
-                PermissionFlags.Start
-            );
-
-            if (!hasPermission)
-            {
-                return StatusCode(403, ApiResponse.Fail<ComposeOperationResponse>(
-                    "You don't have permission to start this compose project",
-                    "PERMISSION_DENIED"
-                ));
-            }
-
-            // Create operation tracking
-            string? projectPath = await ResolveProjectPathAsync(projectName, userId.Value);
-            var operation = await _legacyOperationService.CreateOperationAsync(
-                OperationType.ComposeStart, userId.Value, projectPath: projectPath, projectName: projectName);
-            await _legacyOperationService.UpdateOperationStatusAsync(
-                operation.OperationId, OperationStatus.Running);
-
+            string? projectPath = await ResolveProjectPathAsync(projectName, userId);
             OperationResult result = await _operationService.StartAsync(projectName);
 
-            if (!string.IsNullOrEmpty(result.Message))
-                await _legacyOperationService.AppendLogsAsync(operation.OperationId, result.Message);
-            await _legacyOperationService.UpdateOperationStatusAsync(
-                operation.OperationId,
-                result.Success ? OperationStatus.Completed : OperationStatus.Failed,
-                progress: 100,
-                errorMessage: result.Success ? null : result.Error);
-
-            await _auditService.LogActionAsync(
-                userId.Value,
-                AuditActions.ComposeStart,
-                GetUserIpAddress(),
-                $"Started services for project: {projectName}",
-                resourceType: "compose_project",
-                resourceId: projectName
-            );
-
-            ComposeOperationResponse response = new(
-                operation.OperationId,
-                result.Success ? OperationStatus.Completed : OperationStatus.Failed,
-                result.Message
-            );
-
-            return result.Success
-                ? Ok(ApiResponse.Ok(response))
-                : BadRequest(ApiResponse.Fail<ComposeOperationResponse>(result.Message, "OPERATION_FAILED"));
+            return await FinalizeOperationAsync(
+                OperationType.ComposeStart, userId, projectName, projectPath,
+                AuditActions.ComposeStart, $"Started services for project: {projectName}",
+                result, result.Message);
         }
         catch (Exception ex)
         {
@@ -839,70 +720,16 @@ volumes:
         {
             projectName = Uri.UnescapeDataString(projectName);
 
-            // Self-protection
-            if (await _selfFilterService.IsSelfProjectAsync(projectName))
-            {
-                return StatusCode(403, ApiResponse.Fail<ComposeOperationResponse>(
-                    "This project belongs to the application itself and cannot be modified",
-                    "SELF_PROJECT_PROTECTED"));
-            }
+            var (userId, error) = await AuthorizeProjectOperationAsync(projectName, PermissionFlags.Stop, "stop");
+            if (error != null) return error;
 
-            int? userId = GetCurrentUserId();
-            if (!userId.HasValue)
-            {
-                return Unauthorized(ApiResponse.Fail<ComposeOperationResponse>("User not authenticated"));
-            }
-
-            bool hasPermission = await _permissionService.HasPermissionAsync(
-                userId.Value,
-                ResourceType.ComposeProject,
-                projectName,
-                PermissionFlags.Stop
-            );
-
-            if (!hasPermission)
-            {
-                return StatusCode(403, ApiResponse.Fail<ComposeOperationResponse>(
-                    "You don't have permission to stop this compose project",
-                    "PERMISSION_DENIED"
-                ));
-            }
-
-            // Create operation tracking
-            string? projectPath = await ResolveProjectPathAsync(projectName, userId.Value);
-            var operation = await _legacyOperationService.CreateOperationAsync(
-                OperationType.ComposeStop, userId.Value, projectPath: projectPath, projectName: projectName);
-            await _legacyOperationService.UpdateOperationStatusAsync(
-                operation.OperationId, OperationStatus.Running);
-
+            string? projectPath = await ResolveProjectPathAsync(projectName, userId);
             OperationResult result = await _operationService.StopAsync(projectName);
 
-            if (!string.IsNullOrEmpty(result.Message))
-                await _legacyOperationService.AppendLogsAsync(operation.OperationId, result.Message);
-            await _legacyOperationService.UpdateOperationStatusAsync(
-                operation.OperationId,
-                result.Success ? OperationStatus.Completed : OperationStatus.Failed,
-                progress: 100,
-                errorMessage: result.Success ? null : result.Error);
-
-            await _auditService.LogActionAsync(
-                userId.Value,
-                AuditActions.ComposeStop,
-                GetUserIpAddress(),
-                $"Stopped services for project: {projectName}",
-                resourceType: "compose_project",
-                resourceId: projectName
-            );
-
-            ComposeOperationResponse response = new(
-                operation.OperationId,
-                result.Success ? OperationStatus.Completed : OperationStatus.Failed,
-                result.Message
-            );
-
-            return result.Success
-                ? Ok(ApiResponse.Ok(response))
-                : BadRequest(ApiResponse.Fail<ComposeOperationResponse>(result.Message, "OPERATION_FAILED"));
+            return await FinalizeOperationAsync(
+                OperationType.ComposeStop, userId, projectName, projectPath,
+                AuditActions.ComposeStop, $"Stopped services for project: {projectName}",
+                result, result.Message);
         }
         catch (Exception ex)
         {
@@ -921,70 +748,16 @@ volumes:
         {
             projectName = Uri.UnescapeDataString(projectName);
 
-            // Self-protection
-            if (await _selfFilterService.IsSelfProjectAsync(projectName))
-            {
-                return StatusCode(403, ApiResponse.Fail<ComposeOperationResponse>(
-                    "This project belongs to the application itself and cannot be modified",
-                    "SELF_PROJECT_PROTECTED"));
-            }
+            var (userId, error) = await AuthorizeProjectOperationAsync(projectName, PermissionFlags.Restart, "restart");
+            if (error != null) return error;
 
-            int? userId = GetCurrentUserId();
-            if (!userId.HasValue)
-            {
-                return Unauthorized(ApiResponse.Fail<ComposeOperationResponse>("User not authenticated"));
-            }
-
-            bool hasPermission = await _permissionService.HasPermissionAsync(
-                userId.Value,
-                ResourceType.ComposeProject,
-                projectName,
-                PermissionFlags.Restart
-            );
-
-            if (!hasPermission)
-            {
-                return StatusCode(403, ApiResponse.Fail<ComposeOperationResponse>(
-                    "You don't have permission to restart this compose project",
-                    "PERMISSION_DENIED"
-                ));
-            }
-
-            // Create operation tracking
-            string? projectPath = await ResolveProjectPathAsync(projectName, userId.Value);
-            var operation = await _legacyOperationService.CreateOperationAsync(
-                OperationType.ComposeRestart, userId.Value, projectPath: projectPath, projectName: projectName);
-            await _legacyOperationService.UpdateOperationStatusAsync(
-                operation.OperationId, OperationStatus.Running);
-
+            string? projectPath = await ResolveProjectPathAsync(projectName, userId);
             OperationResult result = await _operationService.RestartAsync(projectName);
 
-            if (!string.IsNullOrEmpty(result.Message))
-                await _legacyOperationService.AppendLogsAsync(operation.OperationId, result.Message);
-            await _legacyOperationService.UpdateOperationStatusAsync(
-                operation.OperationId,
-                result.Success ? OperationStatus.Completed : OperationStatus.Failed,
-                progress: 100,
-                errorMessage: result.Success ? null : result.Error);
-
-            await _auditService.LogActionAsync(
-                userId.Value,
-                AuditActions.ComposeRestart,
-                GetUserIpAddress(),
-                $"Restarted project: {projectName}",
-                resourceType: "compose_project",
-                resourceId: projectName
-            );
-
-            ComposeOperationResponse response = new(
-                operation.OperationId,
-                result.Success ? OperationStatus.Completed : OperationStatus.Failed,
-                result.Message
-            );
-
-            return result.Success
-                ? Ok(ApiResponse.Ok(response))
-                : BadRequest(ApiResponse.Fail<ComposeOperationResponse>(result.Message, "OPERATION_FAILED"));
+            return await FinalizeOperationAsync(
+                OperationType.ComposeRestart, userId, projectName, projectPath,
+                AuditActions.ComposeRestart, $"Restarted project: {projectName}",
+                result, result.Message);
         }
         catch (Exception ex)
         {

--- a/lighthouse-back/lighthouse-back/src/Controllers/ContainersController.cs
+++ b/lighthouse-back/lighthouse-back/src/Controllers/ContainersController.cs
@@ -16,7 +16,7 @@ public class ContainersController : BaseController
     private readonly IPermissionService _permissionService;
     private readonly IContainerUpdateService _containerUpdateService;
     private readonly ISelfFilterService _selfFilterService;
-    private readonly OperationService _operationTrackingService;
+    private readonly IOperationService _operationTrackingService;
     private readonly ILogger<ContainersController> _logger;
 
     public ContainersController(
@@ -24,7 +24,7 @@ public class ContainersController : BaseController
         IPermissionService permissionService,
         IContainerUpdateService containerUpdateService,
         ISelfFilterService selfFilterService,
-        OperationService operationTrackingService,
+        IOperationService operationTrackingService,
         ILogger<ContainersController> logger)
     {
         _dockerService = dockerService;

--- a/lighthouse-back/lighthouse-back/src/Controllers/OperationsController.cs
+++ b/lighthouse-back/lighthouse-back/src/Controllers/OperationsController.cs
@@ -12,12 +12,12 @@ namespace Lighthouse.Controllers;
 [Authorize]
 public class OperationsController : BaseController
 {
-    private readonly OperationService _operationService;
+    private readonly IOperationService _operationService;
     private readonly IAuditService _auditService;
     private readonly ILogger<OperationsController> _logger;
 
     public OperationsController(
-        OperationService operationService,
+        IOperationService operationService,
         IAuditService auditService,
         ILogger<OperationsController> logger)
     {

--- a/lighthouse-back/lighthouse-back/src/Extensions/ServiceCollectionExtensions.cs
+++ b/lighthouse-back/lighthouse-back/src/Extensions/ServiceCollectionExtensions.cs
@@ -41,7 +41,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IUserService, UserService>();
         services.AddScoped<ComposeService>();
         services.AddScoped<IAuditService, AuditService>();
-        services.AddScoped<OperationService>();
+        services.AddScoped<IOperationService, OperationService>();
         services.AddScoped<IPermissionService, PermissionService>();
         services.AddSingleton<DockerService>();
         services.AddSingleton<IDockerImageOperations>(sp => sp.GetRequiredService<DockerService>());

--- a/lighthouse-back/lighthouse-back/src/Services/ComposeUpdateService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/ComposeUpdateService.cs
@@ -68,7 +68,7 @@ public class ComposeUpdateService : IComposeUpdateService
     private readonly DockerCommandExecutorService _dockerExecutor;
     private readonly IComposeEnvFileResolver _envFileResolver;
     private readonly DockerPullProgressParser _progressParser;
-    private readonly OperationService _operationService;
+    private readonly IOperationService _operationService;
     private readonly IRegistryRateLimitGate _rateLimitGate;
     private readonly ILogger<ComposeUpdateService> _logger;
     private readonly UpdateCheckOptions _options;
@@ -80,7 +80,7 @@ public class ComposeUpdateService : IComposeUpdateService
         DockerCommandExecutorService dockerExecutor,
         IComposeEnvFileResolver envFileResolver,
         DockerPullProgressParser progressParser,
-        OperationService operationServiceDb,
+        IOperationService operationServiceDb,
         IRegistryRateLimitGate rateLimitGate,
         IOptions<UpdateCheckOptions> options,
         ILogger<ComposeUpdateService> logger)

--- a/lighthouse-back/lighthouse-back/src/Services/ContainerUpdateService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/ContainerUpdateService.cs
@@ -39,7 +39,7 @@ public class ContainerUpdateService : IContainerUpdateService
     private readonly IComposeUpdateService _composeUpdateService;
     private readonly DockerCommandExecutorService _dockerExecutor;
     private readonly DockerPullProgressParser _progressParser;
-    private readonly OperationService _operationService;
+    private readonly IOperationService _operationService;
     private readonly SseConnectionManagerService _sseManager;
     private readonly IAuditService _auditService;
     private readonly ILogger<ContainerUpdateService> _logger;
@@ -52,7 +52,7 @@ public class ContainerUpdateService : IContainerUpdateService
         IComposeUpdateService composeUpdateService,
         DockerCommandExecutorService dockerExecutor,
         DockerPullProgressParser progressParser,
-        OperationService operationService,
+        IOperationService operationService,
         SseConnectionManagerService sseManager,
         IAuditService auditService,
         ILogger<ContainerUpdateService> logger)

--- a/lighthouse-back/lighthouse-back/src/Services/IOperationService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/IOperationService.cs
@@ -1,0 +1,62 @@
+using Lighthouse.DTOs;
+using Lighthouse.Models;
+
+namespace Lighthouse.Services;
+
+/// <summary>
+/// Tracks long-running operations (compose/container actions, updates) and their logs.
+/// Extracted as an interface so consumers (controllers, background services) can be
+/// unit-tested with a mock instead of the concrete DB-backed implementation.
+/// </summary>
+public interface IOperationService
+{
+    Task<Operation> CreateOperationAsync(
+        string type,
+        int? userId,
+        string? projectPath = null,
+        string? projectName = null,
+        string? containerId = null,
+        string? containerName = null,
+        string? operationId = null);
+
+    Task<bool> UpdateOperationStatusAsync(
+        string operationId,
+        string status,
+        int? progress = null,
+        string? errorMessage = null);
+
+    Task<bool> AppendLogsAsync(string operationId, string logs);
+
+    Task<Operation?> GetOperationAsync(string operationId);
+
+    Task<Operation?> GetOperationByIdAsync(int id);
+
+    Task<List<Operation>> ListOperationsAsync(
+        string? status = null,
+        int? userId = null,
+        DateTime? startDate = null,
+        DateTime? endDate = null,
+        int limit = 100);
+
+    Task<bool> CancelOperationAsync(string operationId);
+
+    Task<bool> AcknowledgeOperationAsync(string operationId);
+
+    Task<int> AcknowledgeAllFailedAsync();
+
+    Task<int> CleanupOldOperationsAsync(DateTime beforeDate);
+
+    Task<Dictionary<string, Operation>> GetLastOperationByEntitiesAsync();
+
+    Task<List<Operation>> ListOperationsFilteredAsync(
+        string? status = null,
+        string? projectName = null,
+        string? containerId = null,
+        int limit = 50);
+
+    Task<int> GetActiveOperationsCountAsync();
+
+    Task<int> ClearAllOperationsAsync();
+
+    Task SendPullProgressAsync(UpdateProgressEvent progress);
+}

--- a/lighthouse-back/lighthouse-back/src/Services/OperationService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/OperationService.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Lighthouse.Services;
 
-public class OperationService
+public class OperationService : IOperationService
 {
     private readonly AppDbContext _context;
     private readonly ILogger<OperationService> _logger;


### PR DESCRIPTION
Batch C **étape 2/2** (après C1 #172). Refacto **behavior-preserving**, verrouillé par des tests contrôleur ajoutés **avant** le dedup.

## Changements

1. **Extraction `IOperationService`** depuis la classe concrète `OperationService` + bascule de tous les consommateurs (`ComposeController`, `ContainersController`, `OperationsController`, `ComposeUpdateService`, `ContainerUpdateService`, `CleanupBackgroundService`) et de la DI vers l'interface. → contrôleur testable avec un mock (solution idiomatique .NET vs `virtual`).
2. **Tests contrôleur** (`ComposeControllerTests`) caractérisant les endpoints : self-protection 403, non-authentifié 401, permission refusée 403, `up` sans compose-file 400, succès 200 — **ajoutés avant** le dedup pour figer le comportement.
3. **Factorisation** des corps dupliqués `up/down/start/stop/restart` en deux helpers :
   - `AuthorizeProjectOperationAsync` (self-protection + auth + permission)
   - `FinalizeOperationAsync` (tracking opération + logs + audit + réponse)
   Chaque endpoint passe de ~70 à ~15 lignes. Préservé : détail d'audit par opération, check compose-file du `up`, `removeVolumes` du `down`, source des logs.

## Métriques & vérif

- `ComposeController` : **1013 → 773 lignes** (1418 → 773 sur C1+C2).
- Backend **395/395** (+6 contrôleur), build 0 warning.
- Smoke runtime : restart d'un projet inexistant → **400 structuré** `OPERATION_FAILED` + opération `compose_restart`/`failed` enregistrée (chemin Finalize complet OK).

## Note

**2.3** (`ListProjects` reconstruit toute la liste unifiée pour un seul projet) **droppé** : données déjà cachées, rebuild en mémoire sur une poignée de projets → gain ne justifie pas de réécrire le matching service. (Comme 2.4.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)