### PR TITLE
perf: decouple SSE broadcasts + dedup process executor (Batch D)

### DIFF
--- a/lighthouse-back/lighthouse-back/src/Services/DockerCommandExecutorService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/DockerCommandExecutorService.cs
@@ -78,6 +78,69 @@ public class DockerCommandExecutorService
     }
 
     /// <summary>
+    /// Runs a process to completion, capturing stdout/stderr and optionally streaming each
+    /// line to callbacks and/or feeding stdin. This is the single implementation shared by
+    /// all the Execute* helpers below.
+    /// </summary>
+    private async Task<(int ExitCode, string Output, string Error)> RunProcessAsync(
+        ProcessStartInfo psi,
+        Action<string>? onOutputLine = null,
+        Action<string>? onErrorLine = null,
+        string? stdinInput = null,
+        CancellationToken cancellationToken = default)
+    {
+        StringBuilder output = new();
+        StringBuilder error = new();
+
+        using Process? process = Process.Start(psi);
+        if (process == null)
+        {
+            return (-1, "", $"Failed to start process: {psi.FileName}");
+        }
+
+        process.OutputDataReceived += (sender, e) =>
+        {
+            if (e.Data == null) return;
+            output.AppendLine(e.Data);
+            try
+            {
+                onOutputLine?.Invoke(e.Data);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error in output callback for command: {Command}", psi.FileName);
+            }
+        };
+
+        process.ErrorDataReceived += (sender, e) =>
+        {
+            if (e.Data == null) return;
+            error.AppendLine(e.Data);
+            try
+            {
+                onErrorLine?.Invoke(e.Data);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error in error callback for command: {Command}", psi.FileName);
+            }
+        };
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        if (stdinInput != null)
+        {
+            await process.StandardInput.WriteAsync(stdinInput);
+            process.StandardInput.Close();
+        }
+
+        await process.WaitForExitAsync(cancellationToken);
+
+        return (process.ExitCode, output.ToString(), error.ToString());
+    }
+
+    /// <summary>
     /// Executes a docker compose command
     /// </summary>
     public async Task<(int ExitCode, string Output, string Error)> ExecuteComposeCommandAsync(
@@ -123,48 +186,18 @@ public class DockerCommandExecutorService
             CreateNoWindow = true
         };
 
-        StringBuilder output = new();
-        StringBuilder error = new();
-
-        using Process? process = Process.Start(psi);
-        if (process == null)
-        {
-            return (-1, "", "Failed to start process");
-        }
-
-        process.OutputDataReceived += (sender, e) =>
-        {
-            if (e.Data != null)
-            {
-                output.AppendLine(e.Data);
-            }
-        };
-
-        process.ErrorDataReceived += (sender, e) =>
-        {
-            if (e.Data != null)
-            {
-                error.AppendLine(e.Data);
-            }
-        };
-
-        process.BeginOutputReadLine();
-        process.BeginErrorReadLine();
-
-        await process.WaitForExitAsync(cancellationToken);
-
-        string outputStr = output.ToString();
-        string errorStr = error.ToString();
+        (int exitCode, string outputStr, string errorStr) =
+            await RunProcessAsync(psi, cancellationToken: cancellationToken);
 
         _logger.LogDebug(
             "Compose command executed: {Command}, Exit Code: {ExitCode}, Output: {Output}, Error: {Error}",
             arguments,
-            process.ExitCode,
+            exitCode,
             outputStr,
             errorStr
         );
 
-        return (process.ExitCode, outputStr, errorStr);
+        return (exitCode, outputStr, errorStr);
     }
 
     /// <summary>
@@ -185,47 +218,17 @@ public class DockerCommandExecutorService
             CreateNoWindow = true
         };
 
-        StringBuilder output = new();
-        StringBuilder error = new();
-
-        using Process? process = Process.Start(psi);
-        if (process == null)
-        {
-            return (-1, "", $"Failed to start process: {command}");
-        }
-
-        process.OutputDataReceived += (sender, e) =>
-        {
-            if (e.Data != null)
-            {
-                output.AppendLine(e.Data);
-            }
-        };
-
-        process.ErrorDataReceived += (sender, e) =>
-        {
-            if (e.Data != null)
-            {
-                error.AppendLine(e.Data);
-            }
-        };
-
-        process.BeginOutputReadLine();
-        process.BeginErrorReadLine();
-
-        await process.WaitForExitAsync(cancellationToken);
-
-        string outputStr = output.ToString();
-        string errorStr = error.ToString();
+        (int exitCode, string outputStr, string errorStr) =
+            await RunProcessAsync(psi, cancellationToken: cancellationToken);
 
         _logger.LogDebug(
             "Command executed: {Command} {Arguments}, Exit Code: {ExitCode}",
             command,
             arguments,
-            process.ExitCode
+            exitCode
         );
 
-        return (process.ExitCode, outputStr, errorStr);
+        return (exitCode, outputStr, errorStr);
     }
 
     /// <summary>
@@ -257,63 +260,17 @@ public class DockerCommandExecutorService
             psi.WorkingDirectory = workingDirectory;
         }
 
-        StringBuilder output = new();
-        StringBuilder error = new();
-
-        using Process? process = Process.Start(psi);
-        if (process == null)
-        {
-            return (-1, "", $"Failed to start process: {command}");
-        }
-
-        process.OutputDataReceived += (sender, e) =>
-        {
-            if (e.Data != null)
-            {
-                output.AppendLine(e.Data);
-                try
-                {
-                    onOutputLine?.Invoke(e.Data);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Error in output callback for command: {Command}", command);
-                }
-            }
-        };
-
-        process.ErrorDataReceived += (sender, e) =>
-        {
-            if (e.Data != null)
-            {
-                error.AppendLine(e.Data);
-                try
-                {
-                    onErrorLine?.Invoke(e.Data);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Error in error callback for command: {Command}", command);
-                }
-            }
-        };
-
-        process.BeginOutputReadLine();
-        process.BeginErrorReadLine();
-
-        await process.WaitForExitAsync(cancellationToken);
-
-        string outputStr = output.ToString();
-        string errorStr = error.ToString();
+        (int exitCode, string outputStr, string errorStr) =
+            await RunProcessAsync(psi, onOutputLine, onErrorLine, cancellationToken: cancellationToken);
 
         _logger.LogDebug(
             "Streaming command executed: {Command} {Arguments}, Exit Code: {ExitCode}",
             command,
             arguments,
-            process.ExitCode
+            exitCode
         );
 
-        return (process.ExitCode, outputStr, errorStr);
+        return (exitCode, outputStr, errorStr);
     }
 
     /// <summary>
@@ -336,51 +293,17 @@ public class DockerCommandExecutorService
             CreateNoWindow = true
         };
 
-        StringBuilder output = new();
-        StringBuilder error = new();
-
-        using Process? process = Process.Start(psi);
-        if (process == null)
-        {
-            return (-1, "", $"Failed to start process: {command}");
-        }
-
-        // Write to stdin and close it
-        await process.StandardInput.WriteAsync(stdinInput);
-        process.StandardInput.Close();
-
-        process.OutputDataReceived += (sender, e) =>
-        {
-            if (e.Data != null)
-            {
-                output.AppendLine(e.Data);
-            }
-        };
-
-        process.ErrorDataReceived += (sender, e) =>
-        {
-            if (e.Data != null)
-            {
-                error.AppendLine(e.Data);
-            }
-        };
-
-        process.BeginOutputReadLine();
-        process.BeginErrorReadLine();
-
-        await process.WaitForExitAsync(cancellationToken);
-
-        string outputStr = output.ToString();
-        string errorStr = error.ToString();
+        (int exitCode, string outputStr, string errorStr) =
+            await RunProcessAsync(psi, stdinInput: stdinInput, cancellationToken: cancellationToken);
 
         // Don't log sensitive data like passwords
         _logger.LogDebug(
             "Command with stdin executed: {Command} {Arguments}, Exit Code: {ExitCode}",
             command,
             arguments,
-            process.ExitCode
+            exitCode
         );
 
-        return (process.ExitCode, outputStr, errorStr);
+        return (exitCode, outputStr, errorStr);
     }
 }

--- a/lighthouse-back/lighthouse-back/src/Services/SseConnectionManagerService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/SseConnectionManagerService.cs
@@ -8,6 +8,12 @@ public class SseClient
     public required HttpResponse Response { get; init; }
     public required string ConnectionId { get; init; }
     public required CancellationToken CancellationToken { get; init; }
+
+    /// <summary>
+    /// Serializes writes to this client's response stream. Each client has its own lock so
+    /// a slow client only blocks its own writes, not broadcasts to everyone else.
+    /// </summary>
+    public SemaphoreSlim WriteLock { get; } = new(1, 1);
 }
 
 /// <summary>
@@ -17,8 +23,11 @@ public class SseClient
 public class SseConnectionManagerService
 {
     private readonly ConcurrentDictionary<string, SseClient> _clients = new();
-    private readonly SemaphoreSlim _broadcastLock = new(1, 1);
     private readonly ILogger<SseConnectionManagerService> _logger;
+
+    // A single write to a client may not hang forever: a stalled connection is dropped
+    // instead of holding up its own queue (broadcasts to other clients are unaffected).
+    private static readonly TimeSpan WriteTimeout = TimeSpan.FromSeconds(10);
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -48,8 +57,9 @@ public class SseConnectionManagerService
     }
 
     /// <summary>
-    /// Broadcasts an SSE event to all connected clients.
-    /// Disconnected clients are automatically removed.
+    /// Broadcasts an SSE event to all connected clients concurrently.
+    /// Each client's write is serialized by its own lock and bounded by a timeout, so a
+    /// slow or stalled client is dropped without holding up delivery to the others.
     /// </summary>
     public async Task BroadcastAsync(string eventType, object data)
     {
@@ -59,73 +69,56 @@ public class SseConnectionManagerService
         string json = JsonSerializer.Serialize(data, JsonOptions);
         string sseMessage = $"event: {eventType}\ndata: {json}\n\n";
 
-        // Serialize broadcasts to prevent concurrent writes to the same HttpResponse streams.
-        // Fire-and-forget callers (e.g. pull progress) can trigger overlapping broadcasts,
-        // and HttpResponse.WriteAsync is not thread-safe.
-        await _broadcastLock.WaitAsync();
-        try
+        // _clients.Values is a snapshot, so removals during writes don't disturb iteration.
+        await Task.WhenAll(_clients.Values.Select(client => WriteToClientInternalAsync(client, sseMessage)));
+    }
+
+    /// <summary>
+    /// Writes a raw SSE message to a specific client. Used by the SSE controller for the
+    /// initial connected event and heartbeats.
+    /// </summary>
+    public async Task WriteToClientAsync(string connectionId, string message)
+    {
+        if (_clients.TryGetValue(connectionId, out var client))
         {
-            List<string> disconnected = [];
-
-            foreach (var (connectionId, client) in _clients)
-            {
-                try
-                {
-                    if (client.CancellationToken.IsCancellationRequested)
-                    {
-                        disconnected.Add(connectionId);
-                        continue;
-                    }
-
-                    await client.Response.WriteAsync(sseMessage, client.CancellationToken);
-                    await client.Response.Body.FlushAsync(client.CancellationToken);
-                }
-                catch (Exception)
-                {
-                    disconnected.Add(connectionId);
-                }
-            }
-
-            foreach (string id in disconnected)
-            {
-                RemoveClient(id);
-            }
-        }
-        finally
-        {
-            _broadcastLock.Release();
+            await WriteToClientInternalAsync(client, message);
         }
     }
 
     /// <summary>
-    /// Writes a raw SSE message to a specific client under the broadcast lock,
-    /// preventing concurrent writes with BroadcastAsync from corrupting the stream.
-    /// Used by the SSE controller for the initial connected event and heartbeats.
+    /// Writes to one client under its own write lock with a timeout. Any failure (cancelled,
+    /// timed out, stream error) drops the client. Never throws.
     /// </summary>
-    public async Task WriteToClientAsync(string connectionId, string message)
+    private async Task WriteToClientInternalAsync(SseClient client, string message)
     {
-        await _broadcastLock.WaitAsync();
+        if (client.CancellationToken.IsCancellationRequested)
+        {
+            RemoveClient(client.ConnectionId);
+            return;
+        }
+
+        bool acquired = false;
         try
         {
-            if (!_clients.TryGetValue(connectionId, out var client))
-                return;
+            await client.WriteLock.WaitAsync(client.CancellationToken);
+            acquired = true;
 
-            if (client.CancellationToken.IsCancellationRequested)
-            {
-                RemoveClient(connectionId);
-                return;
-            }
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(client.CancellationToken);
+            cts.CancelAfter(WriteTimeout);
 
-            await client.Response.WriteAsync(message, client.CancellationToken);
-            await client.Response.Body.FlushAsync(client.CancellationToken);
+            await client.Response.WriteAsync(message, cts.Token);
+            await client.Response.Body.FlushAsync(cts.Token);
         }
         catch (Exception)
         {
-            RemoveClient(connectionId);
+            RemoveClient(client.ConnectionId);
         }
         finally
         {
-            _broadcastLock.Release();
+            if (acquired)
+            {
+                client.WriteLock.Release();
+            }
         }
     }
 


### PR DESCRIPTION
Section 2 — **Batch D** (qualité back). Deux changements contenus, behavior-preserving.

## 2.5 — Broadcast SSE : un client lent ne bloque plus les autres

`BroadcastAsync` prenait **un lock global unique** et écrivait à chaque client **séquentiellement** → un client lent/bloqué retardait la livraison à tous (et les broadcasts suivants). Désormais :
- chaque client a **son propre write-lock** ;
- les écritures sont **concurrentes** (`Task.WhenAll`) avec un **timeout de 10s** par write ;
- un client qui timeout/erreur est retiré sans impacter les autres.
`WriteToClientAsync` (event initial + heartbeats) partage le même chemin par-client.

## 2.9 — Dédup de l'exécuteur de process

`ExecuteAsync` / `ExecuteWithStreamingAsync` / `ExecuteWithStdinAsync` / `ExecuteComposeCommandAsync` dupliquaient la même plomberie (start, capture stdout/stderr, callbacks, stdin, wait). Extraction d'un **`RunProcessAsync`** unique ; chaque méthode publique ne construit plus que son `ProcessStartInfo` + son log. **387 → 309 lignes**.

## Vérif

- SSE **13/13** (format exact, multi-client, camelCase, retrait client déconnecté/en-erreur, broadcasts concurrents) · Backend **395/395** · build 0 warning.
- 2.9 : pas de daemon Docker dispo pour smoke → couvert par build + tests (refacto pur, signatures préservées).

## Suite

**3.3** (audit async via `Channel`) et **3.4** (cohérence du error-handling) — les plus gros restants — dans un batch dédié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)