### PR TITLE
feat: async audit writer + fail-fast secret validation (Batch E)

### DIFF
--- a/lighthouse-back/lighthouse-back.Tests/Services/AuditWriterTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/AuditWriterTests.cs
@@ -1,0 +1,64 @@
+using Lighthouse.BackgroundServices;
+using Lighthouse.Data;
+using Lighthouse.Models;
+using Lighthouse.Services;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Lighthouse.Tests.Services;
+
+public class AuditWriterTests
+{
+    private static AuditLog Entry(string action) =>
+        new() { Action = action, IpAddress = "127.0.0.1", Timestamp = DateTime.UtcNow };
+
+    [Fact]
+    public async Task Writer_PersistsAllEnqueuedEntries()
+    {
+        var services = new ServiceCollection();
+        var dbName = Guid.NewGuid().ToString();
+        services.AddDbContext<AppDbContext>(o => o.UseInMemoryDatabase(dbName));
+        var sp = services.BuildServiceProvider();
+        var scopeFactory = sp.GetRequiredService<IServiceScopeFactory>();
+
+        var queue = new AuditQueue();
+        queue.Enqueue(Entry("a1"));
+        queue.Enqueue(Entry("a2"));
+        queue.Enqueue(Entry("a3"));
+        queue.Complete(); // let the drain loop finish once buffered entries are read
+
+        var writer = new AuditWriterBackgroundService(
+            queue, scopeFactory, NullLogger<AuditWriterBackgroundService>.Instance);
+
+        await writer.StartAsync(CancellationToken.None);
+        await writer.ExecuteTask!; // completes after the completed queue is fully drained
+
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var actions = await db.AuditLogs.Select(a => a.Action).OrderBy(a => a).ToListAsync();
+        actions.Should().BeEquivalentTo(new[] { "a1", "a2", "a3" });
+    }
+
+    [Fact]
+    public async Task AuditService_LogAction_EnqueuesWithoutWritingToDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        using var ctx = new AppDbContext(options);
+
+        var queue = new Mock<IAuditQueue>();
+        var service = new AuditService(ctx, queue.Object, NullLogger<AuditService>.Instance);
+
+        await service.LogActionAsync(userId: 1, action: "user.login", ipAddress: "10.0.0.1",
+            details: "logged in");
+
+        queue.Verify(q => q.Enqueue(It.Is<AuditLog>(a =>
+            a.Action == "user.login" && a.UserId == 1 && a.IpAddress == "10.0.0.1")), Times.Once);
+        // Nothing is written to the database on the request path.
+        (await ctx.AuditLogs.CountAsync()).Should().Be(0);
+    }
+}

--- a/lighthouse-back/lighthouse-back/Program.cs
+++ b/lighthouse-back/lighthouse-back/Program.cs
@@ -110,6 +110,13 @@ if (jwtSecret.Length < 32)
         $"JWT Secret must be at least 32 characters long. Current length: {jwtSecret.Length}. " +
         "Please set a secure JWT_SECRET environment variable.");
 }
+// Fail fast in production if the shipped placeholder secret was never replaced.
+if (builder.Environment.IsProduction() &&
+    jwtSecret == "CHANGE-THIS-SECRET-KEY-IN-PRODUCTION-MIN-32-CHARS")
+{
+    throw new InvalidOperationException(
+        "JWT Secret is still the default placeholder. Set a unique JWT_SECRET before running in production.");
+}
 string jwtIssuer = builder.Configuration["Jwt:Issuer"] ?? "lighthouse";
 string jwtAudience = builder.Configuration["Jwt:Audience"] ?? "lighthouse-client";
 
@@ -235,6 +242,14 @@ else
 {
     if (emailProvider.Equals("Resend", StringComparison.OrdinalIgnoreCase))
     {
+        // In production a missing key almost certainly means misconfiguration; fail fast
+        // rather than silently degrading to a mock that drops password-reset emails.
+        if (builder.Environment.IsProduction())
+        {
+            throw new InvalidOperationException(
+                "Email:Provider is 'Resend' but Email:Resend:ApiKey is not configured. " +
+                "Set the API key or change the provider before running in production.");
+        }
         Log.Warning("Resend provider configured but API key is missing. Falling back to Mock email service");
     }
     builder.Services.AddScoped<Lighthouse.Services.Email.IEmailService, Lighthouse.Services.Email.MockEmailService>();

--- a/lighthouse-back/lighthouse-back/src/BackgroundServices/AuditWriterBackgroundService.cs
+++ b/lighthouse-back/lighthouse-back/src/BackgroundServices/AuditWriterBackgroundService.cs
@@ -1,0 +1,81 @@
+using Lighthouse.Data;
+using Lighthouse.Models;
+using Lighthouse.Services;
+
+namespace Lighthouse.BackgroundServices;
+
+/// <summary>
+/// Drains the audit queue and persists entries to the database in batches, off the request
+/// path. On shutdown it flushes whatever is still buffered so entries are not lost.
+/// </summary>
+public class AuditWriterBackgroundService : BackgroundService
+{
+    private const int MaxBatchSize = 100;
+
+    private readonly IAuditQueue _queue;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<AuditWriterBackgroundService> _logger;
+
+    public AuditWriterBackgroundService(
+        IAuditQueue queue,
+        IServiceScopeFactory scopeFactory,
+        ILogger<AuditWriterBackgroundService> logger)
+    {
+        _queue = queue;
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Audit writer background service started");
+
+        try
+        {
+            await foreach (AuditLog first in _queue.Reader.ReadAllAsync(stoppingToken))
+            {
+                // Coalesce whatever is already buffered into a single batch insert.
+                var batch = new List<AuditLog> { first };
+                while (batch.Count < MaxBatchSize && _queue.Reader.TryRead(out AuditLog? more))
+                {
+                    batch.Add(more);
+                }
+
+                await PersistBatchAsync(batch, stoppingToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected on shutdown.
+        }
+
+        // Final flush: persist anything still buffered without a cancelled token.
+        var remaining = new List<AuditLog>();
+        while (_queue.Reader.TryRead(out AuditLog? entry))
+        {
+            remaining.Add(entry);
+        }
+        if (remaining.Count > 0)
+        {
+            await PersistBatchAsync(remaining, CancellationToken.None);
+        }
+
+        _logger.LogInformation("Audit writer background service stopped");
+    }
+
+    private async Task PersistBatchAsync(List<AuditLog> batch, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using IServiceScope scope = _scopeFactory.CreateScope();
+            AppDbContext db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            db.AuditLogs.AddRange(batch);
+            await db.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // Audit is best-effort: log and drop the batch rather than crash the writer.
+            _logger.LogError(ex, "Failed to persist {Count} audit entries", batch.Count);
+        }
+    }
+}

--- a/lighthouse-back/lighthouse-back/src/Extensions/ServiceCollectionExtensions.cs
+++ b/lighthouse-back/lighthouse-back/src/Extensions/ServiceCollectionExtensions.cs
@@ -41,6 +41,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IUserService, UserService>();
         services.AddScoped<ComposeService>();
         services.AddScoped<IAuditService, AuditService>();
+        services.AddSingleton<IAuditQueue, AuditQueue>();
         services.AddScoped<IOperationService, OperationService>();
         services.AddScoped<IPermissionService, PermissionService>();
         services.AddSingleton<DockerService>();
@@ -146,6 +147,7 @@ public static class ServiceCollectionExtensions
         services.AddHostedService<AutoPruneImagesBackgroundService>();
         services.AddHostedService<AppUpdateNotificationStartupService>();
         services.AddHostedService<Lighthouse.BackgroundServices.CleanupBackgroundService>();
+        services.AddHostedService<Lighthouse.BackgroundServices.AuditWriterBackgroundService>();
         return services;
     }
 }

--- a/lighthouse-back/lighthouse-back/src/Services/AuditQueue.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/AuditQueue.cs
@@ -1,0 +1,34 @@
+using System.Threading.Channels;
+using Lighthouse.Models;
+
+namespace Lighthouse.Services;
+
+/// <summary>
+/// In-memory queue for audit entries. Producers (request handlers) enqueue without hitting
+/// the database; a background writer drains and persists them, keeping the audit write off
+/// the request hot path (and off the single SQLite writer during a request).
+/// </summary>
+public interface IAuditQueue
+{
+    /// <summary>Enqueues an audit entry. Non-blocking; never throws.</summary>
+    void Enqueue(AuditLog entry);
+
+    ChannelReader<AuditLog> Reader { get; }
+
+    /// <summary>Signals that no more entries will be enqueued (used on shutdown).</summary>
+    void Complete();
+}
+
+public class AuditQueue : IAuditQueue
+{
+    // Unbounded: audit volume is low and entries are small, so we prefer never dropping a
+    // security-relevant entry over bounding memory. SingleReader — one background writer.
+    private readonly Channel<AuditLog> _channel = Channel.CreateUnbounded<AuditLog>(
+        new UnboundedChannelOptions { SingleReader = true });
+
+    public void Enqueue(AuditLog entry) => _channel.Writer.TryWrite(entry);
+
+    public ChannelReader<AuditLog> Reader => _channel.Reader;
+
+    public void Complete() => _channel.Writer.TryComplete();
+}

--- a/lighthouse-back/lighthouse-back/src/Services/AuditService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/AuditService.cs
@@ -54,11 +54,13 @@ public interface IAuditService
 public class AuditService : IAuditService
 {
     private readonly AppDbContext _context;
+    private readonly IAuditQueue _queue;
     private readonly ILogger<AuditService> _logger;
 
-    public AuditService(AppDbContext context, ILogger<AuditService> logger)
+    public AuditService(AppDbContext context, IAuditQueue queue, ILogger<AuditService> logger)
     {
         _context = context;
+        _queue = queue;
         _logger = logger;
     }
 
@@ -85,9 +87,10 @@ public class AuditService : IAuditService
     }
 
     /// <summary>
-    /// Logs an audit entry
+    /// Records an audit entry. The entry is enqueued and persisted by a background writer,
+    /// so this never blocks the request on a database write (and never throws).
     /// </summary>
-    public async Task LogActionAsync(
+    public Task LogActionAsync(
         int? userId,
         string action,
         string ipAddress,
@@ -121,22 +124,15 @@ public class AuditService : IAuditService
                 auditLog.AfterState = JsonSerializer.Serialize(after);
             }
 
-            _context.AuditLogs.Add(auditLog);
-            await _context.SaveChangesAsync();
-
-            _logger.LogDebug(
-                "Audit log created: User={UserId}, Action={Action}, Resource={ResourceType}/{ResourceId}",
-                userId,
-                action,
-                resourceType,
-                resourceId
-            );
+            _queue.Enqueue(auditLog);
         }
         catch (Exception ex)
         {
             // Don't throw exceptions from audit logging - log the error but continue
             _logger.LogError(ex, "Error creating audit log entry");
         }
+
+        return Task.CompletedTask;
     }
 
     /// <summary>


### PR DESCRIPTION
Section 3 — **Batch E**.

## 3.3 — Audit asynchrone (hors hot-path)

Les entrées d'audit étaient écrites en DB **inline à chaque requête** (`AuditService.SaveChangesAsync`) → une écriture supplémentaire + contention sur le writer unique SQLite dans le chemin critique.

Désormais :
- `IAuditQueue` (Channel unbounded, in-memory) — `LogActionAsync` **enqueue** (non-bloquant, ne throw jamais).
- `AuditWriterBackgroundService` draine la queue, **insère par batch** (≤100), et flush ce qui reste à l'arrêt.
- Les méthodes de lecture/requête restent inchangées.

Tradeoff : fenêtre de perte si crash avant flush (audit déjà best-effort). Volume faible → queue unbounded (jamais de drop d'entrée sécurité).

## 3.10 — Validation des secrets au démarrage (fail-fast prod)

En **production**, on refuse de démarrer mal configuré :
- JWT secret encore égal au **placeholder** livré → throw.
- `Email:Provider = Resend` mais **pas de clé API** → throw (avant : dégradation silencieuse en Mock qui **jette les emails de reset de mot de passe**).

En développement : fallback Mock conservé.

## Tests & vérif

- **+2** tests (writer persiste toutes les entrées enqueue ; `LogAction` enqueue sans écrire en DB). Backend **397/397**.
- Runtime : GET /api/audit → entrée `audit.view` persistée par le writer (2e appel la renvoie). Prod avorte sur le secret placeholder **et** sur Resend sans clé (les deux guards confirmés).

## Suite (restants section 3)

3.1 (tests front e2e), 3.4 (cohérence error-handling), 3.5 (contention GetUnifiedProjectList), 3.6 (deps front), 3.9 (observabilité). Plus 🟡 sécurité 1.15–1.19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)