### PR TITLE
security: low-severity hardening (1.15–1.19)

### DIFF
--- a/lighthouse-back/lighthouse-back.Tests/Services/PathValidatorTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/PathValidatorTests.cs
@@ -230,8 +230,9 @@ public class PathValidatorTests : IDisposable
     [Fact]
     public void IsValidComposeFilePath_ExtremelyLongPath_ReturnsFalse()
     {
-        // Arrange - Create an extremely long path (> 260 chars on Windows)
-        var longPath = Path.Combine(_testRoot, new string('a', 300), "docker-compose.yml");
+        // Arrange - Create a path longer than the platform limit (260 Windows / 4096 Unix)
+        var longSegment = new string('a', OperatingSystem.IsWindows() ? 300 : 5000);
+        var longPath = Path.Combine(_testRoot, longSegment, "docker-compose.yml");
 
         // Act
         var result = _validator.IsValidComposeFilePath(longPath);

--- a/lighthouse-back/lighthouse-back/Program.cs
+++ b/lighthouse-back/lighthouse-back/Program.cs
@@ -145,6 +145,11 @@ builder.Services.AddAuthentication(options =>
     {
         OnMessageReceived = context =>
         {
+            // SSE/EventSource cannot set headers, so the short-lived access token is passed
+            // in the query string. It is kept out of Serilog request logs (which record the
+            // path, not the query), but it can still appear in browser history / upstream
+            // proxy access logs. Acceptable for a 15-min token; a one-time SSE ticket would
+            // remove even that residual (tracked as a future hardening).
             Microsoft.Extensions.Primitives.StringValues accessToken = context.Request.Query["access_token"];
 
             // If the request is for our SSE endpoints
@@ -199,6 +204,13 @@ builder.Services.AddAuthorization();
 
 // Configure CORS
 string[] corsOrigins = builder.Configuration.GetSection("Cors:Origins").Get<string[]>() ?? ["http://localhost:3030"];
+// A wildcard origin cannot be combined with credentials (the browser rejects it) and is
+// unsafe. Fail fast in production rather than shipping a broken/insecure CORS policy.
+if (builder.Environment.IsProduction() && corsOrigins.Contains("*"))
+{
+    throw new InvalidOperationException(
+        "CORS: wildcard '*' origin is not allowed with credentials. Configure explicit Cors:Origins for production.");
+}
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>

--- a/lighthouse-back/lighthouse-back/src/Controllers/ConfigController.cs
+++ b/lighthouse-back/lighthouse-back/src/Controllers/ConfigController.cs
@@ -21,12 +21,34 @@ public class ConfigController : BaseController
     private readonly AppDbContext _context;
     private readonly ILogger<ConfigController> _logger;
     private readonly LogLevelService _logLevelService;
+    private readonly IConfiguration _configuration;
 
-    public ConfigController(AppDbContext context, ILogger<ConfigController> logger, LogLevelService logLevelService)
+    public ConfigController(AppDbContext context, ILogger<ConfigController> logger, LogLevelService logLevelService, IConfiguration configuration)
     {
         _context = context;
         _logger = logger;
         _logLevelService = logLevelService;
+        _configuration = configuration;
+    }
+
+    /// <summary>
+    /// True when <paramref name="fullPath"/> is one of the allowed roots or lives under one.
+    /// Uses a trailing-separator comparison so a sibling sharing a root's name prefix is rejected.
+    /// </summary>
+    private static bool IsWithinAllowedRoots(string fullPath, string[] allowedRoots)
+    {
+        foreach (string root in allowedRoots)
+        {
+            if (string.Equals(fullPath, root, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            string rootWithSep = root.EndsWith(Path.DirectorySeparatorChar)
+                ? root
+                : root + Path.DirectorySeparatorChar;
+            if (fullPath.StartsWith(rootWithSep, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
     }
 
     #region Directory Browser
@@ -42,6 +64,14 @@ public class ConfigController : BaseController
     {
         try
         {
+            // Optional allowlist: when Config:AllowedBrowsePaths is set, the filesystem
+            // browser is restricted to those subtrees. Empty (default) keeps full access
+            // for the admin folder/file picker.
+            string[] allowedRoots = (_configuration.GetSection("Config:AllowedBrowsePaths").Get<string[]>() ?? [])
+                .Where(p => !string.IsNullOrWhiteSpace(p))
+                .Select(Path.GetFullPath)
+                .ToArray();
+
             // Default to root directories if no path provided
             string currentPath = path ?? string.Empty;
 
@@ -51,6 +81,11 @@ public class ConfigController : BaseController
                 try
                 {
                     currentPath = Path.GetFullPath(currentPath);
+                    if (allowedRoots.Length > 0 && !IsWithinAllowedRoots(currentPath, allowedRoots))
+                    {
+                        _logger.LogWarning("Directory browse denied outside allowed roots: {Path}", currentPath);
+                        return StatusCode(403, ApiResponse.Fail<DirectoryBrowseResult>("Access denied to this directory"));
+                    }
                     if (!Directory.Exists(currentPath))
                     {
                         return BadRequest(ApiResponse.Fail<DirectoryBrowseResult>("Directory does not exist"));
@@ -71,6 +106,16 @@ public class ConfigController : BaseController
 
             if (string.IsNullOrEmpty(currentPath))
             {
+                // With an allowlist configured, the roots are the only entry points.
+                if (allowedRoots.Length > 0)
+                {
+                    result.Directories = allowedRoots
+                        .Where(Directory.Exists)
+                        .Select(root => new DirectoryBrowseInfo { Name = root, Path = root, IsAccessible = true })
+                        .ToList();
+                    return Ok(ApiResponse.Ok(result, "Directory contents retrieved successfully"));
+                }
+
                 // Return root drives/directories
                 if (OperatingSystem.IsWindows())
                 {

--- a/lighthouse-back/lighthouse-back/src/Security/ApiKeyProtector.cs
+++ b/lighthouse-back/lighthouse-back/src/Security/ApiKeyProtector.cs
@@ -5,10 +5,18 @@ namespace Lighthouse.Security;
 
 /// <summary>
 /// Decrypts API keys that were encrypted at build time using OpenSSL AES-256-CBC with PBKDF2.
-/// This prevents keys from appearing in plain text in Docker image layers or config files.
+/// This keeps keys out of plain text in Docker image layers or config files.
 /// </summary>
+/// <remarks>
+/// SECURITY NOTE: the passphrase below is compiled into the binary, so this is
+/// <b>obfuscation, not confidentiality</b>. Anyone with the image/binary can recover the
+/// key. It only raises the bar against casual inspection of image layers; it is not a
+/// substitute for injecting real secrets at runtime (env var / secret store). Do not rely
+/// on it to protect high-value credentials.
+/// </remarks>
 public static class ApiKeyProtector
 {
+    // Obfuscation passphrase only — see the security note on the class. Not a secret.
     private static readonly byte[] Passphrase = Encoding.UTF8.GetBytes("dcm-k3y-sh13ld-x7q9m2v4");
     private const int Iterations = 100000;
     private const int SaltLength = 8;

--- a/lighthouse-back/lighthouse-back/src/Services/PathValidatorService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/PathValidatorService.cs
@@ -42,9 +42,10 @@ public class PathValidatorService : IPathValidator
             return false;
         }
 
-        // Check for path length (Windows MAX_PATH is 260, but modern Windows supports longer paths)
-        // We use a conservative limit to ensure compatibility
-        if (userProvidedPath.Length > 260)
+        // Guard against unreasonably long paths. Windows MAX_PATH is 260; Linux/macOS allow
+        // much longer, so don't reject valid long paths there.
+        int maxPathLength = OperatingSystem.IsWindows() ? 260 : 4096;
+        if (userProvidedPath.Length > maxPathLength)
         {
             _logger.LogWarning("Path validation failed: path too long ({Length} chars)", userProvidedPath.Length);
             return false;


### PR DESCRIPTION
Section 1 — les 🟡 restants. Ferme la partie sécurité de la review.

| # | Fix |
|---|-----|
| 1.16 | **Limite de path** : le cap 260 ne s'applique plus qu'à Windows ; 4096 sous Linux/macOS → plus de rejet de paths longs valides. |
| 1.17 | **CORS** : fail-fast en production si `Cors:Origins` contient `"*"` (invalide avec credentials **et** dangereux). |
| 1.19 | **Directory browser** : allowlist **opt-in** (`Config:AllowedBrowsePaths`). Si configuré, le picker admin est restreint à ces sous-arbres (racine + descendants, séparateur-safe) ; vide (défaut) = accès complet inchangé. Le listing racine renvoie les roots autorisés au lieu de tous les disques. |
| 1.15 | **ApiKeyProtector** : documenté — la passphrase compilée est de l'**obfuscation, pas de la confidentialité** (pas un substitut à l'injection de secret au runtime). |
| 1.18 | **Token SSE en query** : documenté le résiduel (historique navigateur / logs proxy ; hors Serilog qui logue le path pas la query). Fix propre = ticket SSE one-time (hardening futur). |

## Vérif

- Test `PathValidatorTests` rendu OS-aware pour la nouvelle limite. Backend **397/397**.
- Runtime 1.19 : avec allowlist → browse **inside 200 / outside 403** / listing racine = roots autorisés ; sans allowlist → **non-restreint** (aucune régression).

## État review

**Section 1 (sécurité) : terminée** (1.1→1.19). Section 2 terminée. Section 3 : restent 3.1 (tests front), 3.4 (cohérence erreurs), 3.5, 3.6, 3.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)