### PR TITLE
feat(logs): container log streaming rework + pagination + permission fix (PR1/3, #42)

### DIFF
--- a/lighthouse-back/lighthouse-back.Tests/Controllers/ContainersControllerLogsTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Controllers/ContainersControllerLogsTests.cs
@@ -1,0 +1,233 @@
+using Lighthouse.Controllers;
+using Lighthouse.DTOs;
+using Lighthouse.Models;
+using Lighthouse.Services;
+using Lighthouse.Services.LogStreaming;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+
+namespace Lighthouse.Tests.Controllers;
+
+public class ContainersControllerLogsTests
+{
+    private readonly Mock<IPermissionService> _permission = new();
+    private readonly Mock<IContainerUpdateService> _updates = new();
+    private readonly Mock<ISelfFilterService> _selfFilter = new();
+    private readonly Mock<IOperationService> _operations = new();
+    private readonly Mock<IContainerLogService> _logService = new();
+    private readonly Mock<IAuditService> _audit = new();
+
+    private static readonly ContainerLogSource Source =
+        new("abc123", "web", "proj", "web", Tty: false);
+
+    private ContainersController Build(bool authenticated = true)
+    {
+        // Permissive defaults; individual tests override.
+        _selfFilter.Setup(s => s.IsSelfContainerAsync(It.IsAny<string>())).ReturnsAsync(false);
+        _permission.Setup(p => p.HasContainerPermissionAsync(
+                It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<PermissionFlags>()))
+            .ReturnsAsync(true);
+        _logService.Setup(l => l.GetLogSourceAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Source);
+
+        // DockerService is concrete; the log endpoints never touch it. Building the client
+        // does not open a connection, so an in-memory host string is enough.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Docker:Host"] = "npipe://./pipe/docker_engine"
+            }).Build();
+        var docker = new DockerService(config, NullLogger<DockerService>.Instance,
+            new CrashLoopDetectionService(NullLogger<CrashLoopDetectionService>.Instance));
+
+        var controller = new ContainersController(
+            docker, _permission.Object, _updates.Object, _selfFilter.Object,
+            _operations.Object, _logService.Object, _audit.Object,
+            NullLogger<ContainersController>.Instance);
+
+        var identity = authenticated
+            ? new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "1") }, "test")
+            : new ClaimsIdentity();
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(identity),
+                Response = { Body = new MemoryStream() }
+            }
+        };
+        return controller;
+    }
+
+    private static async IAsyncEnumerable<LogEntryDto> Empty([EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+
+    private static int? StatusOf(ActionResult<ApiResponse<LogPageDto>> result) =>
+        (result.Result as ObjectResult)?.StatusCode;
+
+    // ---- history endpoint ----
+
+    [Fact]
+    public async Task History_Unauthenticated_Returns401()
+    {
+        var controller = Build(authenticated: false);
+
+        var result = await controller.GetContainerLogHistory("abc123");
+
+        StatusOf(result).Should().Be(401);
+    }
+
+    [Fact]
+    public async Task History_ContainerNotFound_Returns404()
+    {
+        var controller = Build();
+        _logService.Setup(l => l.GetLogSourceAsync("missing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ContainerLogSource?)null);
+
+        var result = await controller.GetContainerLogHistory("missing");
+
+        StatusOf(result).Should().Be(404);
+    }
+
+    [Fact]
+    public async Task History_SelfContainer_Returns403()
+    {
+        var controller = Build();
+        _selfFilter.Setup(s => s.IsSelfContainerAsync("abc123")).ReturnsAsync(true);
+
+        var result = await controller.GetContainerLogHistory("abc123");
+
+        StatusOf(result).Should().Be(403);
+    }
+
+    [Fact]
+    public async Task History_NoLogsPermission_Returns403()
+    {
+        var controller = Build();
+        _permission.Setup(p => p.HasContainerPermissionAsync(
+                1, "web", "proj", PermissionFlags.Logs)).ReturnsAsync(false);
+
+        var result = await controller.GetContainerLogHistory("abc123");
+
+        StatusOf(result).Should().Be(403);
+    }
+
+    [Fact]
+    public async Task History_Success_Returns200WithPage()
+    {
+        var controller = Build();
+        var page = new LogPageDto(
+            new List<LogEntryDto> { new("2026-07-04T12:00:00Z", "abc123", "web", "web", "stdout", "hi") },
+            HasMore: false);
+        _logService.Setup(l => l.GetHistoryAsync(Source, It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page);
+
+        var result = await controller.GetContainerLogHistory("abc123");
+
+        (result.Result as OkObjectResult)?.StatusCode.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task History_TailIsClampedToMax()
+    {
+        var controller = Build();
+        int? capturedTail = null;
+        _logService.Setup(l => l.GetHistoryAsync(Source, It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<ContainerLogSource, int, string?, CancellationToken>((_, tail, _, _) => capturedTail = tail)
+            .ReturnsAsync(new LogPageDto(new List<LogEntryDto>(), false));
+
+        await controller.GetContainerLogHistory("abc123", tail: 999999);
+
+        capturedTail.Should().Be(1000);
+    }
+
+    [Fact]
+    public async Task History_InvalidUntil_Returns400()
+    {
+        var controller = Build();
+        _logService.Setup(l => l.GetHistoryAsync(Source, It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new FormatException("bad cursor"));
+
+        var result = await controller.GetContainerLogHistory("abc123", until: "garbage");
+
+        StatusOf(result).Should().Be(400);
+    }
+
+    // ---- stream endpoint (permission gap regression) ----
+
+    [Fact]
+    public async Task Stream_Unauthenticated_Returns401()
+    {
+        var controller = Build(authenticated: false);
+
+        await controller.StreamContainerLogs("abc123");
+
+        controller.Response.StatusCode.Should().Be(401);
+        _logService.Verify(l => l.StreamAsync(It.IsAny<ContainerLogSource>(), It.IsAny<int>(),
+            It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Stream_ContainerNotFound_Returns404()
+    {
+        var controller = Build();
+        _logService.Setup(l => l.GetLogSourceAsync("missing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ContainerLogSource?)null);
+
+        await controller.StreamContainerLogs("missing");
+
+        controller.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task Stream_SelfContainer_Returns403()
+    {
+        var controller = Build();
+        _selfFilter.Setup(s => s.IsSelfContainerAsync("abc123")).ReturnsAsync(true);
+
+        await controller.StreamContainerLogs("abc123");
+
+        controller.Response.StatusCode.Should().Be(403);
+    }
+
+    // The regression test for the permission gap: the stream endpoint previously
+    // skipped the per-container Logs permission check that the one-shot enforced.
+    [Fact]
+    public async Task Stream_NoLogsPermission_Returns403AndDoesNotStream()
+    {
+        var controller = Build();
+        _permission.Setup(p => p.HasContainerPermissionAsync(
+                1, "web", "proj", PermissionFlags.Logs)).ReturnsAsync(false);
+
+        await controller.StreamContainerLogs("abc123");
+
+        controller.Response.StatusCode.Should().Be(403);
+        _logService.Verify(l => l.StreamAsync(It.IsAny<ContainerLogSource>(), It.IsAny<int>(),
+            It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Stream_Authorized_AuditsAndStreams()
+    {
+        var controller = Build();
+        _logService.Setup(l => l.StreamAsync(Source, It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Empty());
+
+        await controller.StreamContainerLogs("abc123");
+
+        _audit.Verify(a => a.LogActionAsync(
+            1, AuditActions.ContainerLogs, It.IsAny<string>(),
+            It.IsAny<string?>(), "container", "abc123", null, null), Times.Once);
+        _logService.Verify(l => l.StreamAsync(Source, It.IsAny<int>(),
+            It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/lighthouse-back/lighthouse-back.Tests/Services/LogStreaming/LogLineBufferTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/LogStreaming/LogLineBufferTests.cs
@@ -1,0 +1,128 @@
+using System.Text;
+using Docker.DotNet;
+using FluentAssertions;
+using Lighthouse.Services.LogStreaming;
+
+namespace Lighthouse.Tests.Services.LogStreaming;
+
+public class LogLineBufferTests
+{
+    private static ReadOnlySpan<byte> Utf8(string s) => Encoding.UTF8.GetBytes(s);
+
+    [Fact]
+    public void SingleCompleteLine_IsYielded()
+    {
+        var buffer = new LogLineBuffer();
+        buffer.Feed(MultiplexedStream.TargetStream.StandardOut, Utf8("hello\n"));
+
+        var lines = buffer.DrainCompletedLines().ToList();
+
+        lines.Should().ContainSingle();
+        lines[0].Line.Should().Be("hello");
+        lines[0].Stream.Should().Be(LogLineBuffer.StdoutStream);
+    }
+
+    [Fact]
+    public void LineSplitAcrossTwoFeeds_IsReassembled()
+    {
+        var buffer = new LogLineBuffer();
+        buffer.Feed(MultiplexedStream.TargetStream.StandardOut, Utf8("hel"));
+        buffer.DrainCompletedLines().Should().BeEmpty();
+
+        buffer.Feed(MultiplexedStream.TargetStream.StandardOut, Utf8("lo\n"));
+        var lines = buffer.DrainCompletedLines().ToList();
+
+        lines.Should().ContainSingle();
+        lines[0].Line.Should().Be("hello");
+    }
+
+    [Fact]
+    public void MultiByteCharSplitAcrossReads_DecodesCorrectly()
+    {
+        // 'é' (U+00E9) is 0xC3 0xA9 in UTF-8; split it across two feeds.
+        byte[] full = Encoding.UTF8.GetBytes("café\n");
+        int splitAt = Array.IndexOf(full, (byte)0xC3) + 1; // between the two bytes of 'é'
+
+        var buffer = new LogLineBuffer();
+        buffer.Feed(MultiplexedStream.TargetStream.StandardOut, full.AsSpan(0, splitAt));
+        buffer.Feed(MultiplexedStream.TargetStream.StandardOut, full.AsSpan(splitAt));
+
+        var lines = buffer.DrainCompletedLines().ToList();
+        lines.Should().ContainSingle();
+        lines[0].Line.Should().Be("café");
+    }
+
+    [Fact]
+    public void MultipleLinesInOneChunk_AreAllYielded()
+    {
+        var buffer = new LogLineBuffer();
+        buffer.Feed(MultiplexedStream.TargetStream.StandardOut, Utf8("a\nb\nc\n"));
+
+        var lines = buffer.DrainCompletedLines().Select(l => l.Line).ToList();
+
+        lines.Should().Equal("a", "b", "c");
+    }
+
+    [Fact]
+    public void TrailingCarriageReturn_IsStripped()
+    {
+        var buffer = new LogLineBuffer();
+        buffer.Feed(MultiplexedStream.TargetStream.StandardOut, Utf8("windows\r\n"));
+
+        var lines = buffer.DrainCompletedLines().ToList();
+        lines[0].Line.Should().Be("windows");
+    }
+
+    [Fact]
+    public void StdoutAndStderr_AreTaggedIndependently()
+    {
+        var buffer = new LogLineBuffer();
+        buffer.Feed(MultiplexedStream.TargetStream.StandardOut, Utf8("out\n"));
+        buffer.Feed(MultiplexedStream.TargetStream.StandardError, Utf8("err\n"));
+
+        var lines = buffer.DrainCompletedLines().ToList();
+
+        lines.Should().HaveCount(2);
+        lines.Should().Contain(l => l.Line == "out" && l.Stream == LogLineBuffer.StdoutStream);
+        lines.Should().Contain(l => l.Line == "err" && l.Stream == LogLineBuffer.StderrStream);
+    }
+
+    [Fact]
+    public void InterleavedStdoutStderr_KeepSeparateAccumulators()
+    {
+        var buffer = new LogLineBuffer();
+        buffer.Feed(MultiplexedStream.TargetStream.StandardOut, Utf8("ou"));
+        buffer.Feed(MultiplexedStream.TargetStream.StandardError, Utf8("er"));
+        buffer.Feed(MultiplexedStream.TargetStream.StandardOut, Utf8("t\n"));
+        buffer.Feed(MultiplexedStream.TargetStream.StandardError, Utf8("r\n"));
+
+        var lines = buffer.DrainCompletedLines().Select(l => l.Line).ToList();
+        lines.Should().Contain("out");
+        lines.Should().Contain("err");
+    }
+
+    [Fact]
+    public void Flush_EmitsTrailingUnterminatedLine()
+    {
+        var buffer = new LogLineBuffer();
+        buffer.Feed(MultiplexedStream.TargetStream.StandardOut, Utf8("no newline"));
+        buffer.DrainCompletedLines().Should().BeEmpty();
+
+        buffer.Flush();
+        var lines = buffer.DrainCompletedLines().ToList();
+
+        lines.Should().ContainSingle();
+        lines[0].Line.Should().Be("no newline");
+    }
+
+    [Fact]
+    public void Flush_WithNoPendingBytes_YieldsNothing()
+    {
+        var buffer = new LogLineBuffer();
+        buffer.Feed(MultiplexedStream.TargetStream.StandardOut, Utf8("done\n"));
+        buffer.DrainCompletedLines().ToList();
+
+        buffer.Flush();
+        buffer.DrainCompletedLines().Should().BeEmpty();
+    }
+}

--- a/lighthouse-back/lighthouse-back.Tests/Services/LogStreaming/LogTimestampUtilTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/LogStreaming/LogTimestampUtilTests.cs
@@ -1,0 +1,83 @@
+using FluentAssertions;
+using Lighthouse.Services.LogStreaming;
+
+namespace Lighthouse.Tests.Services.LogStreaming;
+
+public class LogTimestampUtilTests
+{
+    [Fact]
+    public void TrySplitTimestampPrefix_WithNanoFraction_SplitsCorrectly()
+    {
+        bool ok = LogTimestampUtil.TrySplitTimestampPrefix(
+            "2026-07-04T12:00:00.123456789Z hello world", out string ts, out string msg);
+
+        ok.Should().BeTrue();
+        ts.Should().Be("2026-07-04T12:00:00.123456789Z");
+        msg.Should().Be("hello world");
+    }
+
+    [Fact]
+    public void TrySplitTimestampPrefix_WithoutFraction_SplitsCorrectly()
+    {
+        bool ok = LogTimestampUtil.TrySplitTimestampPrefix(
+            "2026-07-04T12:00:00Z message", out string ts, out string msg);
+
+        ok.Should().BeTrue();
+        ts.Should().Be("2026-07-04T12:00:00Z");
+        msg.Should().Be("message");
+    }
+
+    [Fact]
+    public void TrySplitTimestampPrefix_NoPrefix_ReturnsFalseAndWholeLine()
+    {
+        bool ok = LogTimestampUtil.TrySplitTimestampPrefix(
+            "just a plain line", out string ts, out string msg);
+
+        ok.Should().BeFalse();
+        ts.Should().BeEmpty();
+        msg.Should().Be("just a plain line");
+    }
+
+    [Fact]
+    public void TrySplitTimestampPrefix_EmptyLine_ReturnsFalse()
+    {
+        bool ok = LogTimestampUtil.TrySplitTimestampPrefix("", out string ts, out string msg);
+
+        ok.Should().BeFalse();
+        ts.Should().BeEmpty();
+        msg.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToUnixNano_PreservesFullNanosecondPrecision()
+    {
+        // 2026-07-04T12:00:00Z == 1783166400 unix seconds
+        string result = LogTimestampUtil.ToUnixNano("2026-07-04T12:00:00.123456789Z");
+
+        result.Should().Be("1783166400.123456789");
+    }
+
+    [Fact]
+    public void ToUnixNano_NoFraction_PadsToNineZeros()
+    {
+        string result = LogTimestampUtil.ToUnixNano("2026-07-04T12:00:00Z");
+
+        result.Should().Be("1783166400.000000000");
+    }
+
+    [Fact]
+    public void ToUnixNano_ShortFraction_RightPads()
+    {
+        string result = LogTimestampUtil.ToUnixNano("2026-07-04T12:00:00.5Z");
+
+        result.Should().Be("1783166400.500000000");
+    }
+
+    [Fact]
+    public void ToUnixNano_Malformed_Throws()
+    {
+        Action act = () => LogTimestampUtil.ToUnixNano("not-a-timestamp");
+
+        act.Should().Throw<FormatException>();
+    }
+}

--- a/lighthouse-back/lighthouse-back/src/Controllers/ContainersController.cs
+++ b/lighthouse-back/lighthouse-back/src/Controllers/ContainersController.cs
@@ -1,6 +1,7 @@
 using Lighthouse.DTOs;
 using Lighthouse.Models;
 using Lighthouse.Services;
+using Lighthouse.Services.LogStreaming;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
@@ -17,6 +18,8 @@ public class ContainersController : BaseController
     private readonly IContainerUpdateService _containerUpdateService;
     private readonly ISelfFilterService _selfFilterService;
     private readonly IOperationService _operationTrackingService;
+    private readonly IContainerLogService _containerLogService;
+    private readonly IAuditService _auditService;
     private readonly ILogger<ContainersController> _logger;
 
     public ContainersController(
@@ -25,6 +28,8 @@ public class ContainersController : BaseController
         IContainerUpdateService containerUpdateService,
         ISelfFilterService selfFilterService,
         IOperationService operationTrackingService,
+        IContainerLogService containerLogService,
+        IAuditService auditService,
         ILogger<ContainersController> logger)
     {
         _dockerService = dockerService;
@@ -32,6 +37,8 @@ public class ContainersController : BaseController
         _containerUpdateService = containerUpdateService;
         _selfFilterService = selfFilterService;
         _operationTrackingService = operationTrackingService;
+        _containerLogService = containerLogService;
+        _auditService = auditService;
         _logger = logger;
     }
 
@@ -534,15 +541,109 @@ public class ContainersController : BaseController
     }
 
     /// <summary>
-    /// Stream container logs in real-time via SSE.
-    /// Sends historical logs first, then follows new logs.
+    /// Get a page of historical container logs, for infinite scroll-up pagination.
+    /// Entries are sorted ascending by timestamp.
     /// </summary>
     /// <param name="id">Container ID</param>
-    /// <param name="tail">Number of historical lines (default 100)</param>
+    /// <param name="tail">Number of lines per page (default 100, max 1000)</param>
+    /// <param name="until">RFC3339Nano cursor — return lines up to this timestamp (default: now)</param>
+    /// <param name="cancellationToken">Request cancellation.</param>
+    [HttpGet("{id}/logs/history")]
+    [ProducesResponseType(typeof(ApiResponse<LogPageDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ApiResponse<LogPageDto>>> GetContainerLogHistory(
+        string id,
+        [FromQuery] int tail = 100,
+        [FromQuery] string? until = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            tail = Math.Clamp(tail, 1, 1000);
+
+            int? userId = GetCurrentUserId();
+            if (!userId.HasValue)
+            {
+                return Unauthorized(ApiResponse.Fail<LogPageDto>("User not authenticated"));
+            }
+
+            ContainerLogSource? source = await _containerLogService.GetLogSourceAsync(id, cancellationToken);
+            if (source == null)
+            {
+                return NotFound(ApiResponse.Fail<LogPageDto>(
+                    "Container not found", "RESOURCE_NOT_FOUND"));
+            }
+
+            // Self-protection
+            if (await _selfFilterService.IsSelfContainerAsync(id))
+            {
+                return StatusCode(403, ApiResponse.Fail<LogPageDto>(
+                    "This container belongs to the application itself and cannot be accessed",
+                    "SELF_CONTAINER_PROTECTED"));
+            }
+
+            // Check Logs permission (direct or inherited from project)
+            bool hasPermission = await _permissionService.HasContainerPermissionAsync(
+                userId.Value, source.Name, source.Project, PermissionFlags.Logs);
+            if (!hasPermission)
+            {
+                return StatusCode(403, ApiResponse.Fail<LogPageDto>(
+                    "You don't have permission to view logs for this container",
+                    "PERMISSION_DENIED"));
+            }
+
+            LogPageDto page = await _containerLogService.GetHistoryAsync(source, tail, until, cancellationToken);
+            return Ok(ApiResponse.Ok(page, $"Retrieved {page.Entries.Count} log lines"));
+        }
+        catch (FormatException)
+        {
+            return BadRequest(ApiResponse.Fail<LogPageDto>(
+                "Invalid 'until' timestamp", "VALIDATION_ERROR"));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving log history for container {ContainerId}", id);
+            return StatusCode(500, ApiResponse.Fail<LogPageDto>(
+                "Failed to retrieve container logs", "DOCKER_OPERATION_FAILED"));
+        }
+    }
+
+    /// <summary>
+    /// Stream container logs in real-time via SSE.
+    /// Sends the last <paramref name="tail"/> lines first, then follows new logs.
+    /// Events: connected, logs (batched JSON), error. See LogEntryDto for the entry shape.
+    /// </summary>
+    /// <param name="id">Container ID</param>
+    /// <param name="tail">Number of historical lines (default 100, max 1000)</param>
+    /// <param name="since">RFC3339Nano resume cursor — replay all lines since this timestamp (tail is ignored)</param>
     /// <param name="cancellationToken">Cancels the stream when the client disconnects.</param>
     [HttpGet("{id}/logs/stream")]
-    public async Task StreamContainerLogs(string id, [FromQuery] int tail = 100, CancellationToken cancellationToken = default)
+    public async Task StreamContainerLogs(
+        string id,
+        [FromQuery] int tail = 100,
+        [FromQuery] string? since = null,
+        CancellationToken cancellationToken = default)
     {
+        tail = Math.Clamp(tail, 1, 1000);
+
+        int? userId = GetCurrentUserId();
+        if (!userId.HasValue)
+        {
+            Response.StatusCode = 401;
+            await Response.WriteAsJsonAsync(ApiResponse.Fail<object>(
+                "User not authenticated", "UNAUTHORIZED"), cancellationToken);
+            return;
+        }
+
+        ContainerLogSource? source = await _containerLogService.GetLogSourceAsync(id, cancellationToken);
+        if (source == null)
+        {
+            Response.StatusCode = 404;
+            await Response.WriteAsJsonAsync(ApiResponse.Fail<object>(
+                "Container not found", "RESOURCE_NOT_FOUND"), cancellationToken);
+            return;
+        }
+
         // Self-protection
         if (await _selfFilterService.IsSelfContainerAsync(id))
         {
@@ -553,46 +654,48 @@ public class ContainersController : BaseController
             return;
         }
 
-        Response.Headers.ContentType = "text/event-stream";
-        Response.Headers.CacheControl = "no-cache";
-
-        // Only set Connection header for HTTP/1.1 (not valid for HTTP/2+)
-        if (Request.Protocol == "HTTP/1.1")
+        // Check Logs permission (direct or inherited from project) — same rule as the
+        // one-shot and history endpoints.
+        bool hasPermission = await _permissionService.HasContainerPermissionAsync(
+            userId.Value, source.Name, source.Project, PermissionFlags.Logs);
+        if (!hasPermission)
         {
-            Response.Headers.Connection = "keep-alive";
+            Response.StatusCode = 403;
+            await Response.WriteAsJsonAsync(ApiResponse.Fail<object>(
+                "You don't have permission to view logs for this container",
+                "PERMISSION_DENIED"), cancellationToken);
+            return;
         }
 
-        try
+        // Validate the resume cursor before committing to SSE headers
+        if (since != null)
         {
-            await _dockerService.StreamContainerLogsAsync(
-                id,
-                tail,
-                async (line) =>
-                {
-                    string escaped = line.Replace("\\", "\\\\").Replace("\n", "\\n").Replace("\r", "");
-                    await Response.WriteAsync($"event: log\ndata: {escaped}\n\n", cancellationToken);
-                    await Response.Body.FlushAsync(cancellationToken);
-                },
-                cancellationToken
-            );
-        }
-        catch (OperationCanceledException)
-        {
-            // Client disconnected — normal behavior
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error streaming logs for container {ContainerId}", id);
             try
             {
-                await Response.WriteAsync($"event: error\ndata: Failed to stream logs\n\n", cancellationToken);
-                await Response.Body.FlushAsync(cancellationToken);
+                LogTimestampUtil.ToUnixNano(since);
             }
-            catch
+            catch (FormatException)
             {
-                // Client already disconnected
+                Response.StatusCode = 400;
+                await Response.WriteAsJsonAsync(ApiResponse.Fail<object>(
+                    "Invalid 'since' timestamp", "VALIDATION_ERROR"), cancellationToken);
+                return;
             }
         }
+
+        await _auditService.LogActionAsync(
+            userId.Value,
+            AuditActions.ContainerLogs,
+            GetUserIpAddress(),
+            details: $"Streaming logs for container {source.Name}",
+            resourceType: "container",
+            resourceId: source.Id);
+
+        await SseLogStreamWriter.RunAsync(
+            HttpContext,
+            _containerLogService.StreamAsync(source, tail, since, cancellationToken),
+            _logger,
+            cancellationToken);
     }
 
     /// <summary>

--- a/lighthouse-back/lighthouse-back/src/DTOs/LogDtos.cs
+++ b/lighthouse-back/lighthouse-back/src/DTOs/LogDtos.cs
@@ -1,0 +1,28 @@
+namespace Lighthouse.DTOs;
+
+/// <summary>
+/// A single structured log line from a container.
+/// </summary>
+/// <param name="Timestamp">
+/// RFC3339Nano timestamp exactly as emitted by Docker (string to preserve nanosecond
+/// precision — it doubles as the pagination cursor). Empty when the line had no
+/// parseable timestamp prefix (e.g. TTY progress output); such entries must not be
+/// used as cursors.
+/// </param>
+/// <param name="ContainerId">Full container ID.</param>
+/// <param name="ContainerName">Container name without the leading '/'.</param>
+/// <param name="Service">com.docker.compose.service label, null for standalone containers.</param>
+/// <param name="Stream">"stdout" or "stderr".</param>
+/// <param name="Message">Raw line content, ANSI codes preserved, timestamp prefix stripped.</param>
+public record LogEntryDto(
+    string Timestamp,
+    string ContainerId,
+    string ContainerName,
+    string? Service,
+    string Stream,
+    string Message);
+
+/// <summary>
+/// One page of historical logs. Entries are sorted ascending by timestamp.
+/// </summary>
+public record LogPageDto(List<LogEntryDto> Entries, bool HasMore);

--- a/lighthouse-back/lighthouse-back/src/Extensions/ServiceCollectionExtensions.cs
+++ b/lighthouse-back/lighthouse-back/src/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using DockerComposeManager.Services.Security;
 using Lighthouse.Configuration;
 using Lighthouse.Services;
+using Lighthouse.Services.LogStreaming;
 
 namespace Lighthouse.Extensions;
 
@@ -46,6 +47,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IPermissionService, PermissionService>();
         services.AddSingleton<DockerService>();
         services.AddSingleton<IDockerImageOperations>(sp => sp.GetRequiredService<DockerService>());
+        services.AddSingleton<IContainerLogService, ContainerLogService>();
         services.AddScoped<IImageService, ImageService>();
         services.AddScoped<IRegistryCredentialService, RegistryCredentialService>();
         return services;

--- a/lighthouse-back/lighthouse-back/src/Services/AuditService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/AuditService.cs
@@ -355,6 +355,7 @@ public static class AuditActions
     public const string ContainerRemove = "container.remove";
     public const string ContainerList = "container.list";
     public const string ContainerInspect = "container.inspect";
+    public const string ContainerLogs = "container.logs";
 
     // Image actions
     public const string ImageRemove = "image.remove";

--- a/lighthouse-back/lighthouse-back/src/Services/DockerService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/DockerService.cs
@@ -428,50 +428,6 @@ public class DockerService : IDockerImageOperations
     }
 
     /// <summary>
-    /// Streams container logs in real-time using Docker's follow mode.
-    /// Calls onLogLine for each log line received.
-    /// </summary>
-    public async Task StreamContainerLogsAsync(
-        string containerId,
-        int tail,
-        Func<string, Task> onLogLine,
-        CancellationToken cancellationToken)
-    {
-        ContainerLogsParameters parameters = new()
-        {
-            ShowStdout = true,
-            ShowStderr = true,
-            Tail = tail.ToString(),
-            Timestamps = true,
-            Follow = true
-        };
-
-        MultiplexedStream stream = await _dockerClient.Containers.GetContainerLogsAsync(
-            containerId,
-            true,
-            parameters,
-            cancellationToken
-        );
-
-        byte[] buffer = new byte[8192];
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            MultiplexedStream.ReadResult result = await stream.ReadOutputAsync(buffer, 0, buffer.Length, cancellationToken);
-
-            if (result.Count == 0)
-                break;
-
-            string text = System.Text.Encoding.UTF8.GetString(buffer, 0, result.Count);
-            string[] lines = text.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-
-            foreach (string line in lines)
-            {
-                await onLogLine(line);
-            }
-        }
-    }
-
-    /// <summary>
     /// Normalizes a docker container name by removing the leading '/' that the Docker API returns.
     /// Returns "unknown" if the provided name is null or whitespace.
     /// </summary>

--- a/lighthouse-back/lighthouse-back/src/Services/LogStreaming/ContainerLogService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/LogStreaming/ContainerLogService.cs
@@ -1,0 +1,156 @@
+using System.Runtime.CompilerServices;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Lighthouse.DTOs;
+
+namespace Lighthouse.Services.LogStreaming;
+
+/// <summary>
+/// Reads container logs through the Docker Engine API with correct multiplexed-stream
+/// framing (see <see cref="LogLineBuffer"/>) and per-line RFC3339Nano timestamps.
+/// </summary>
+public class ContainerLogService : IContainerLogService, IDisposable
+{
+    private const string ComposeProjectLabel = "com.docker.compose.project";
+    private const string ComposeServiceLabel = "com.docker.compose.service";
+    private const int ReadBufferSize = 8192;
+
+    private readonly DockerClient _dockerClient;
+    private readonly ILogger<ContainerLogService> _logger;
+
+    public ContainerLogService(IConfiguration configuration, ILogger<ContainerLogService> logger)
+    {
+        _logger = logger;
+
+        string? dockerHost = configuration["Docker:Host"];
+        if (string.IsNullOrEmpty(dockerHost))
+        {
+            throw new ArgumentException("Docker host is not configured. Set 'Docker__Host' environment variable.");
+        }
+
+        _dockerClient = new DockerClientConfiguration(new Uri(dockerHost)).CreateClient();
+    }
+
+    public async Task<ContainerLogSource?> GetLogSourceAsync(string containerId, CancellationToken ct = default)
+    {
+        try
+        {
+            ContainerInspectResponse inspect = await _dockerClient.Containers.InspectContainerAsync(containerId, ct);
+
+            IDictionary<string, string>? labels = inspect.Config?.Labels;
+            string? project = null;
+            string? service = null;
+            labels?.TryGetValue(ComposeProjectLabel, out project);
+            labels?.TryGetValue(ComposeServiceLabel, out service);
+
+            return new ContainerLogSource(
+                Id: inspect.ID,
+                Name: inspect.Name?.TrimStart('/') ?? "unknown",
+                Project: project,
+                Service: service,
+                Tty: inspect.Config?.Tty ?? false);
+        }
+        catch (DockerContainerNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    public async Task<LogPageDto> GetHistoryAsync(ContainerLogSource source, int tail, string? until, CancellationToken ct = default)
+    {
+        ContainerLogsParameters parameters = new()
+        {
+            ShowStdout = true,
+            ShowStderr = true,
+            Timestamps = true,
+            Tail = tail.ToString(),
+            Until = until != null ? LogTimestampUtil.ToUnixNano(until) : null
+        };
+
+        List<LogEntryDto> entries = new();
+        using MultiplexedStream stream = await _dockerClient.Containers.GetContainerLogsAsync(
+            source.Id, source.Tty, parameters, ct);
+
+        LogLineBuffer buffer = new();
+        byte[] readBuffer = new byte[ReadBufferSize];
+
+        while (true)
+        {
+            MultiplexedStream.ReadResult result = await stream.ReadOutputAsync(readBuffer, 0, readBuffer.Length, ct);
+            if (result.Count == 0)
+            {
+                break;
+            }
+
+            buffer.Feed(result.Target, readBuffer.AsSpan(0, result.Count));
+            foreach ((string line, string streamName) in buffer.DrainCompletedLines())
+            {
+                entries.Add(ToEntry(source, line, streamName));
+            }
+        }
+
+        buffer.Flush();
+        foreach ((string line, string streamName) in buffer.DrainCompletedLines())
+        {
+            entries.Add(ToEntry(source, line, streamName));
+        }
+
+        return new LogPageDto(entries, HasMore: entries.Count >= tail);
+    }
+
+    public async IAsyncEnumerable<LogEntryDto> StreamAsync(
+        ContainerLogSource source,
+        int tail,
+        string? since,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        ContainerLogsParameters parameters = new()
+        {
+            ShowStdout = true,
+            ShowStderr = true,
+            Timestamps = true,
+            Follow = true,
+            Tail = since != null ? "all" : tail.ToString(),
+            Since = since != null ? LogTimestampUtil.ToUnixNano(since) : null
+        };
+
+        using MultiplexedStream stream = await _dockerClient.Containers.GetContainerLogsAsync(
+            source.Id, source.Tty, parameters, ct);
+
+        LogLineBuffer buffer = new();
+        byte[] readBuffer = new byte[ReadBufferSize];
+
+        while (!ct.IsCancellationRequested)
+        {
+            MultiplexedStream.ReadResult result = await stream.ReadOutputAsync(readBuffer, 0, readBuffer.Length, ct);
+            if (result.Count == 0)
+            {
+                break;
+            }
+
+            buffer.Feed(result.Target, readBuffer.AsSpan(0, result.Count));
+            foreach ((string line, string streamName) in buffer.DrainCompletedLines())
+            {
+                yield return ToEntry(source, line, streamName);
+            }
+        }
+
+        buffer.Flush();
+        foreach ((string line, string streamName) in buffer.DrainCompletedLines())
+        {
+            yield return ToEntry(source, line, streamName);
+        }
+    }
+
+    private static LogEntryDto ToEntry(ContainerLogSource source, string line, string streamName)
+    {
+        LogTimestampUtil.TrySplitTimestampPrefix(line, out string timestamp, out string message);
+        return new LogEntryDto(timestamp, source.Id, source.Name, source.Service, streamName, message);
+    }
+
+    public void Dispose()
+    {
+        _dockerClient.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/lighthouse-back/lighthouse-back/src/Services/LogStreaming/IContainerLogService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/LogStreaming/IContainerLogService.cs
@@ -1,0 +1,39 @@
+using Lighthouse.DTOs;
+
+namespace Lighthouse.Services.LogStreaming;
+
+/// <summary>
+/// Identity and log-relevant configuration of a container, resolved once per request.
+/// </summary>
+/// <param name="Id">Full container ID.</param>
+/// <param name="Name">Container name without the leading '/'.</param>
+/// <param name="Project">com.docker.compose.project label, null for standalone containers.</param>
+/// <param name="Service">com.docker.compose.service label, null for standalone containers.</param>
+/// <param name="Tty">Whether the container was created with a TTY (changes log stream framing).</param>
+public record ContainerLogSource(string Id, string Name, string? Project, string? Service, bool Tty);
+
+/// <summary>
+/// Structured access to container logs: history pages (until-cursor pagination)
+/// and follow streams, both emitting <see cref="LogEntryDto"/>.
+/// </summary>
+public interface IContainerLogService
+{
+    /// <summary>
+    /// Inspects the container. Returns null when it does not exist.
+    /// </summary>
+    Task<ContainerLogSource?> GetLogSourceAsync(string containerId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Fetches one page of historical logs, ascending by timestamp.
+    /// <paramref name="until"/> is an RFC3339Nano cursor (exclusive-ish: Docker treats
+    /// it inclusively, callers dedup the boundary); null means "up to now".
+    /// </summary>
+    Task<LogPageDto> GetHistoryAsync(ContainerLogSource source, int tail, string? until, CancellationToken ct = default);
+
+    /// <summary>
+    /// Follows the container's log output. When <paramref name="since"/> is set
+    /// (RFC3339Nano, reconnect resume), <paramref name="tail"/> is ignored and all
+    /// lines since that timestamp are replayed.
+    /// </summary>
+    IAsyncEnumerable<LogEntryDto> StreamAsync(ContainerLogSource source, int tail, string? since, CancellationToken ct = default);
+}

--- a/lighthouse-back/lighthouse-back/src/Services/LogStreaming/LogLineBuffer.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/LogStreaming/LogLineBuffer.cs
@@ -1,0 +1,94 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using Docker.DotNet;
+
+namespace Lighthouse.Services.LogStreaming;
+
+/// <summary>
+/// Accumulates raw bytes from a Docker log stream, per output target, and yields only
+/// completed lines decoded as UTF-8. Decoding happens after line assembly, so a read
+/// boundary falling inside a line — or inside a multi-byte character — never produces
+/// partial or corrupted output.
+/// </summary>
+public class LogLineBuffer
+{
+    public const string StdoutStream = "stdout";
+    public const string StderrStream = "stderr";
+
+    private readonly List<byte> _stdout = new();
+    private readonly List<byte> _stderr = new();
+    private readonly Queue<(string Line, string Stream)> _completed = new();
+
+    /// <summary>
+    /// Feeds a chunk of raw bytes read from the stream for the given target.
+    /// TTY streams have a single output; feed them as StandardOut.
+    /// </summary>
+    public void Feed(MultiplexedStream.TargetStream target, ReadOnlySpan<byte> data)
+    {
+        bool isStderr = target == MultiplexedStream.TargetStream.StandardError;
+        List<byte> accumulator = isStderr ? _stderr : _stdout;
+        string streamName = isStderr ? StderrStream : StdoutStream;
+
+        int start = 0;
+        for (int i = 0; i < data.Length; i++)
+        {
+            if (data[i] != (byte)'\n')
+            {
+                continue;
+            }
+
+            AppendRange(accumulator, data[start..i]);
+            _completed.Enqueue((DecodeAndClear(accumulator), streamName));
+            start = i + 1;
+        }
+
+        AppendRange(accumulator, data[start..]);
+    }
+
+    /// <summary>
+    /// Returns all lines completed since the last drain, in arrival order.
+    /// </summary>
+    public IEnumerable<(string Line, string Stream)> DrainCompletedLines()
+    {
+        while (_completed.Count > 0)
+        {
+            yield return _completed.Dequeue();
+        }
+    }
+
+    /// <summary>
+    /// Emits any trailing unterminated line. Call once at end of stream.
+    /// </summary>
+    public void Flush()
+    {
+        if (_stdout.Count > 0)
+        {
+            _completed.Enqueue((DecodeAndClear(_stdout), StdoutStream));
+        }
+        if (_stderr.Count > 0)
+        {
+            _completed.Enqueue((DecodeAndClear(_stderr), StderrStream));
+        }
+    }
+
+    private static void AppendRange(List<byte> accumulator, ReadOnlySpan<byte> data)
+    {
+        if (!data.IsEmpty)
+        {
+            accumulator.AddRange(data);
+        }
+    }
+
+    private static string DecodeAndClear(List<byte> accumulator)
+    {
+        ReadOnlySpan<byte> bytes = CollectionsMarshal.AsSpan(accumulator);
+        if (bytes.Length > 0 && bytes[^1] == (byte)'\r')
+        {
+            bytes = bytes[..^1];
+        }
+
+        string line = Encoding.UTF8.GetString(bytes);
+        accumulator.Clear();
+        return line;
+    }
+}

--- a/lighthouse-back/lighthouse-back/src/Services/LogStreaming/LogTimestampUtil.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/LogStreaming/LogTimestampUtil.cs
@@ -1,0 +1,77 @@
+using System.Globalization;
+
+namespace Lighthouse.Services.LogStreaming;
+
+/// <summary>
+/// Helpers for the RFC3339Nano timestamps Docker prepends to log lines when
+/// Timestamps=true, and for converting them to the unix-with-nanoseconds form the
+/// Docker Engine expects for the since/until log filters.
+/// </summary>
+public static class LogTimestampUtil
+{
+    /// <summary>
+    /// Splits the "2026-07-04T12:00:00.123456789Z " prefix off a log line.
+    /// Returns false (empty timestamp, whole line as message) when the prefix is
+    /// missing or malformed — e.g. TTY progress output using bare '\r'.
+    /// </summary>
+    public static bool TrySplitTimestampPrefix(string rawLine, out string timestamp, out string message)
+    {
+        int spaceIndex = rawLine.IndexOf(' ');
+        if (spaceIndex > 0)
+        {
+            string candidate = rawLine[..spaceIndex];
+            if (LooksLikeRfc3339(candidate))
+            {
+                timestamp = candidate;
+                message = rawLine[(spaceIndex + 1)..];
+                return true;
+            }
+        }
+
+        timestamp = string.Empty;
+        message = rawLine;
+        return false;
+    }
+
+    /// <summary>
+    /// Converts an RFC3339Nano timestamp to "unixSeconds.nanoseconds" for Docker's
+    /// since/until parameters. The fractional part is carried textually because
+    /// DateTimeOffset ticks (100ns) cannot represent full nanosecond precision.
+    /// Throws FormatException on unparseable input.
+    /// </summary>
+    public static string ToUnixNano(string rfc3339Nano)
+    {
+        string fraction = string.Empty;
+        string withoutFraction = rfc3339Nano;
+
+        int dotIndex = rfc3339Nano.IndexOf('.');
+        if (dotIndex >= 0)
+        {
+            int end = dotIndex + 1;
+            while (end < rfc3339Nano.Length && char.IsAsciiDigit(rfc3339Nano[end]))
+            {
+                end++;
+            }
+
+            fraction = rfc3339Nano[(dotIndex + 1)..end];
+            withoutFraction = rfc3339Nano[..dotIndex] + rfc3339Nano[end..];
+        }
+
+        DateTimeOffset parsed = DateTimeOffset.Parse(
+            withoutFraction,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal);
+
+        fraction = fraction.Length > 9 ? fraction[..9] : fraction.PadRight(9, '0');
+        return $"{parsed.ToUnixTimeSeconds()}.{fraction}";
+    }
+
+    private static bool LooksLikeRfc3339(string value)
+    {
+        return value.Length >= 20
+            && value[4] == '-'
+            && value[7] == '-'
+            && value[10] == 'T'
+            && DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out _);
+    }
+}

--- a/lighthouse-back/lighthouse-back/src/Services/LogStreaming/SseLogStreamWriter.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/LogStreaming/SseLogStreamWriter.cs
@@ -1,0 +1,170 @@
+using System.Text.Json;
+using System.Threading.Channels;
+using Lighthouse.DTOs;
+
+namespace Lighthouse.Services.LogStreaming;
+
+/// <summary>
+/// Writes a stream of log entries to an HTTP response as Server-Sent Events.
+/// Entries are batched (flushed every 150ms or 256 entries) into `event: logs`
+/// frames with a JSON payload; a `: heartbeat` comment is written every 30s of
+/// inactivity. The bounded channel applies backpressure to the producer when the
+/// client reads slowly. Entries are written in producer order — the producer is
+/// responsible for chronological ordering.
+/// </summary>
+public static class SseLogStreamWriter
+{
+    private static readonly TimeSpan FlushInterval = TimeSpan.FromMilliseconds(150);
+    private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(30);
+    private const int MaxBatchSize = 256;
+    private const int ChannelCapacity = 10_000;
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public static async Task RunAsync(
+        HttpContext httpContext,
+        IAsyncEnumerable<LogEntryDto> entries,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        HttpResponse response = httpContext.Response;
+        response.Headers.ContentType = "text/event-stream";
+        response.Headers.CacheControl = "no-cache";
+
+        // Only set Connection header for HTTP/1.1 (not valid for HTTP/2+)
+        if (httpContext.Request.Protocol == "HTTP/1.1")
+        {
+            response.Headers.Connection = "keep-alive";
+        }
+
+        try
+        {
+            await WriteEventAsync(response, "connected",
+                JsonSerializer.Serialize(new { streamId = Guid.NewGuid().ToString() }, JsonOptions), ct);
+
+            Channel<LogEntryDto> channel = Channel.CreateBounded<LogEntryDto>(new BoundedChannelOptions(ChannelCapacity)
+            {
+                SingleReader = true,
+                SingleWriter = true,
+                FullMode = BoundedChannelFullMode.Wait
+            });
+
+            Task producer = PumpAsync(entries, channel.Writer, ct);
+            await ConsumeAsync(response, channel.Reader, ct);
+            await producer;
+        }
+        catch (OperationCanceledException)
+        {
+            // Client disconnected — normal behavior
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error writing SSE log stream");
+            try
+            {
+                await WriteEventAsync(response, "error",
+                    JsonSerializer.Serialize(new { message = "Failed to stream logs", code = "LOG_STREAM_FAILED" }, JsonOptions),
+                    CancellationToken.None);
+            }
+            catch
+            {
+                // Client already disconnected
+            }
+        }
+    }
+
+    private static async Task PumpAsync(
+        IAsyncEnumerable<LogEntryDto> entries,
+        ChannelWriter<LogEntryDto> writer,
+        CancellationToken ct)
+    {
+        try
+        {
+            await foreach (LogEntryDto entry in entries.WithCancellation(ct))
+            {
+                await writer.WriteAsync(entry, ct);
+            }
+            writer.Complete();
+        }
+        catch (Exception ex)
+        {
+            writer.Complete(ex);
+        }
+    }
+
+    private static async Task ConsumeAsync(
+        HttpResponse response,
+        ChannelReader<LogEntryDto> reader,
+        CancellationToken ct)
+    {
+        List<LogEntryDto> batch = new(MaxBatchSize);
+        DateTime lastWrite = DateTime.UtcNow;
+        DateTime? batchDeadline = null;
+
+        while (true)
+        {
+            TimeSpan wait = batchDeadline.HasValue
+                ? batchDeadline.Value - DateTime.UtcNow
+                : HeartbeatInterval - (DateTime.UtcNow - lastWrite);
+            if (wait < TimeSpan.Zero)
+            {
+                wait = TimeSpan.Zero;
+            }
+
+            bool completed = false;
+            bool timedOut = false;
+            using (CancellationTokenSource timeout = CancellationTokenSource.CreateLinkedTokenSource(ct))
+            {
+                timeout.CancelAfter(wait);
+                try
+                {
+                    completed = !await reader.WaitToReadAsync(timeout.Token);
+                }
+                catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+                {
+                    timedOut = true;
+                }
+            }
+
+            if (!completed && !timedOut)
+            {
+                while (batch.Count < MaxBatchSize && reader.TryRead(out LogEntryDto? entry))
+                {
+                    batch.Add(entry);
+                }
+                batchDeadline ??= DateTime.UtcNow + FlushInterval;
+
+                if (batch.Count < MaxBatchSize)
+                {
+                    continue; // accumulate until the flush deadline or a full batch
+                }
+            }
+
+            if (batch.Count > 0)
+            {
+                await WriteEventAsync(response, "logs",
+                    JsonSerializer.Serialize(new { entries = batch }, JsonOptions), ct);
+                batch.Clear();
+                batchDeadline = null;
+                lastWrite = DateTime.UtcNow;
+            }
+            else if (timedOut)
+            {
+                await response.WriteAsync(": heartbeat\n\n", ct);
+                await response.Body.FlushAsync(ct);
+                lastWrite = DateTime.UtcNow;
+            }
+
+            if (completed)
+            {
+                return;
+            }
+        }
+    }
+
+    private static async Task WriteEventAsync(HttpResponse response, string eventName, string jsonData, CancellationToken ct)
+    {
+        await response.WriteAsync($"event: {eventName}\ndata: {jsonData}\n\n", ct);
+        await response.Body.FlushAsync(ct);
+    }
+}

--- a/lighthouse-front/src/lib/components/compose/ComposeLogs.svelte
+++ b/lighthouse-front/src/lib/components/compose/ComposeLogs.svelte
@@ -20,6 +20,26 @@
 		raw: string;
 	}
 
+	// Matches the backend LogEntryDto (PR1 SSE contract).
+	interface BackendLogEntry {
+		timestamp: string;
+		containerId: string;
+		containerName: string;
+		service: string | null;
+		stream: 'stdout' | 'stderr';
+		message: string;
+	}
+
+	function toLogEntry(entry: BackendLogEntry): LogEntry {
+		const parsed = entry.timestamp ? new Date(entry.timestamp) : new Date();
+		return {
+			timestamp: isNaN(parsed.getTime()) ? new Date() : parsed,
+			service: entry.service || entry.containerName || entry.containerId.substring(0, 12),
+			message: entry.message,
+			raw: entry.message
+		};
+	}
+
 	let logs = $state<LogEntry[]>([]);
 	let isStreaming = $state(false);
 	let error = $state<string | null>(null);
@@ -49,43 +69,6 @@
 			serviceColors.set(serviceName, colorPalette[colorIndex]);
 		}
 		return serviceColors.get(serviceName)!;
-	}
-
-	function parseLogLine(rawLog: string): LogEntry {
-		const pipeIndex = rawLog.indexOf('|');
-
-		if (pipeIndex === -1) {
-			const svc = containerId ? containerName || containerId.substring(0, 12) : 'unknown';
-			return {
-				timestamp: new Date(),
-				service: svc,
-				message: rawLog,
-				raw: rawLog
-			};
-		}
-
-		const serviceName = rawLog.substring(0, pipeIndex).trim();
-		const content = rawLog.substring(pipeIndex + 1).trim();
-
-		const timestampMatch = content.match(
-			/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?)\s+(.*)$/
-		);
-
-		if (timestampMatch) {
-			return {
-				timestamp: new Date(timestampMatch[1]),
-				service: serviceName,
-				message: timestampMatch[2],
-				raw: rawLog
-			};
-		}
-
-		return {
-			timestamp: new Date(),
-			service: serviceName,
-			message: content,
-			raw: rawLog
-		};
 	}
 
 	// Auto-scroll effect
@@ -132,15 +115,25 @@
 
 			eventSource = new EventSource(streamUrl);
 
-			eventSource.addEventListener('log', (e: MessageEvent) => {
-				const line = e.data;
-				const parsed = parseLogLine(line);
-				logs = [...logs, parsed];
+			// New SSE contract (PR1): batched `logs` events carrying structured JSON entries.
+			// This is a compatibility shim until the dedicated LogViewer (PR3) lands.
+			eventSource.addEventListener('logs', (e: MessageEvent) => {
+				try {
+					const payload = JSON.parse(e.data) as { entries: BackendLogEntry[] };
+					const mapped = payload.entries.map(toLogEntry);
+					logs = [...logs, ...mapped];
+				} catch (err) {
+					logger.error('[STREAMING] Failed to parse log batch:', err);
+				}
 			});
 
 			eventSource.addEventListener('error', (e: MessageEvent) => {
 				if (e.data) {
-					error = e.data;
+					try {
+						error = (JSON.parse(e.data) as { message?: string }).message ?? e.data;
+					} catch {
+						error = e.data;
+					}
 				}
 			});
 


### PR DESCRIPTION
Part 1 of 3 for the log system re-architecture (#42). Backend only, container logs.

## What & why

The container log stream had three real problems this fixes:

1. **Security gap** — `GET {id}/logs/stream` never checked the per-container `Logs` permission that the one-shot `GET {id}/logs` enforces. Any authenticated user could stream any container's logs. The stream endpoint now runs the same 401/404/self/`PermissionFlags.Logs` checks **before** switching to SSE.
2. **Broken framing** — the follow path UTF8-decoded raw 8KB chunks and split on `\n`, corrupting lines split across reads / multi-byte chars, and hardcoded `tty:true` (leaking 8-byte multiplex headers on non-TTY containers). Replaced by `LogLineBuffer` (byte-level, per-stream, decode-completed-lines-only) reading with the container's real TTY flag.
3. **No history pagination** — only `tail` existed. New `GET {id}/logs/history?tail&until` walks backwards via Docker `until` cursors (RFC3339Nano → unix-nanos, lossless), for the infinite scroll-up the issue asks for.

## Contract (consumed by PR3 front)

- `LogEntryDto { timestamp, containerId, containerName, service, stream, message }`, `LogPageDto { entries, hasMore }`.
- SSE: `connected`, batched `logs` (JSON, 150ms/256), `error`, 30s heartbeat. `SseLogStreamWriter` uses a bounded channel for backpressure.
- Stream `since=<ts>` resume param for reconnect.

A minimal shim in `ComposeLogs.svelte` keeps the deployed app working on the new event shape until the full viewer rewrite (PR3).

## Tests

`LogLineBufferTests`, `LogTimestampUtilTests`, `ContainersControllerLogsTests` (incl. the permission-gap regression: stream returns 403 and never opens without `Logs`). Full backend suite green (421 passed).

## Manual verification (reviewer / author, needs a live daemon)

- non-TTY `alpine sh -c 'while true; do echo out; echo err >&2; sleep 1; done'` → correct stdout/stderr tags, no header garbage
- a `-t` TTY container
- `curl -N ".../logs/stream?tail=10&access_token=..."`
- history walk with `until` ×2 → no gaps/dupes
- user without `Logs` permission → 403 on the stream

## Next

PR2: unified compose-project log endpoints (fan-in/merge). PR3: new virtualized frontend viewer (badges, filters, search, ANSI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)