### PR TITLE
feat(logs): unified compose project log endpoints — fan-in/merge (PR2/3, #42)

### DIFF
--- a/lighthouse-back/lighthouse-back.Tests/Controllers/ComposeControllerTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Controllers/ComposeControllerTests.cs
@@ -22,6 +22,7 @@ public class ComposeControllerTests
     private readonly Mock<IComposeFileCacheService> _fileCache = new();
     private readonly Mock<IImageUpdateCacheService> _imageCache = new();
     private readonly Mock<ISelfFilterService> _selfFilter = new();
+    private readonly Mock<Lighthouse.Services.LogStreaming.IContainerLogService> _containerLogService = new();
 
     private ComposeController Build(bool authenticated = true)
     {
@@ -35,10 +36,16 @@ public class ComposeControllerTests
                 It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .ReturnsAsync(new Operation { OperationId = "op1", Type = OperationType.ComposeUp, Status = OperationStatus.Pending });
 
+        var coordinator = new Lighthouse.Services.LogStreaming.ComposeLogStreamCoordinator(
+            _containerLogService.Object,
+            new Lighthouse.Services.DockerEventBus(NullLogger<Lighthouse.Services.DockerEventBus>.Instance),
+            NullLogger<Lighthouse.Services.LogStreaming.ComposeLogStreamCoordinator>.Instance);
+
         var controller = new ComposeController(
             _discovery.Object, _composeOp.Object, _legacyOp.Object, _audit.Object,
             _permission.Object, NullLogger<ComposeController>.Instance, _matching.Object,
-            _fileCache.Object, _imageCache.Object, _selfFilter.Object);
+            _fileCache.Object, _imageCache.Object, _selfFilter.Object,
+            _containerLogService.Object, coordinator);
 
         // Set the current user on the controller context (BaseController reads claims).
         var identity = authenticated
@@ -130,5 +137,95 @@ public class ComposeControllerTests
         var result = await controller.DownProject("proj", new ComposeDownRequest());
 
         StatusOf(result).Should().Be(403);
+    }
+
+    // ---- log history endpoint ----
+
+    private static int? StatusOfLogs(ActionResult<ApiResponse<LogPageDto>> result) =>
+        (result.Result as ObjectResult)?.StatusCode;
+
+    [Fact]
+    public async Task LogHistory_SelfProject_Returns403()
+    {
+        var controller = Build();
+        _selfFilter.Setup(s => s.IsSelfProjectAsync("self")).ReturnsAsync(true);
+
+        var result = await controller.GetProjectLogHistory("self");
+
+        StatusOfLogs(result).Should().Be(403);
+    }
+
+    [Fact]
+    public async Task LogHistory_Unauthenticated_Returns401()
+    {
+        var controller = Build(authenticated: false);
+
+        var result = await controller.GetProjectLogHistory("proj");
+
+        StatusOfLogs(result).Should().Be(401);
+    }
+
+    [Fact]
+    public async Task LogHistory_NoLogsPermission_Returns403()
+    {
+        var controller = Build();
+        _permission.Setup(p => p.HasPermissionAsync(
+                It.IsAny<int>(), ResourceType.ComposeProject, "proj", PermissionFlags.Logs))
+            .ReturnsAsync(false);
+
+        var result = await controller.GetProjectLogHistory("proj");
+
+        StatusOfLogs(result).Should().Be(403);
+    }
+
+    [Fact]
+    public async Task LogHistory_Success_MergesContainersAndAudits()
+    {
+        var controller = Build();
+        _containerLogService.Setup(l => l.ListProjectContainerIdsAsync("proj", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { "a", "b" });
+        _containerLogService.Setup(l => l.GetLogSourceAsync("a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Lighthouse.Services.LogStreaming.ContainerLogSource("a", "a", "proj", "web", false));
+        _containerLogService.Setup(l => l.GetLogSourceAsync("b", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Lighthouse.Services.LogStreaming.ContainerLogSource("b", "b", "proj", "db", false));
+        _containerLogService.Setup(l => l.GetHistoryAsync(
+                It.Is<Lighthouse.Services.LogStreaming.ContainerLogSource>(s => s.Id == "a"), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LogPageDto(new List<LogEntryDto> { new("2026-07-04T12:00:00.000000000Z", "a", "a", "web", "stdout", "a1") }, false));
+        _containerLogService.Setup(l => l.GetHistoryAsync(
+                It.Is<Lighthouse.Services.LogStreaming.ContainerLogSource>(s => s.Id == "b"), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LogPageDto(new List<LogEntryDto> { new("2026-07-04T12:00:01.000000000Z", "b", "b", "db", "stdout", "b1") }, false));
+
+        var result = await controller.GetProjectLogHistory("proj");
+
+        (result.Result as OkObjectResult)?.StatusCode.Should().Be(200);
+        var page = ((result.Result as OkObjectResult)?.Value as ApiResponse<LogPageDto>)?.Data;
+        page!.Entries.Select(e => e.Message).Should().Equal("a1", "b1");
+        _audit.Verify(a => a.LogActionAsync(
+            1, AuditActions.ComposeLogs, It.IsAny<string>(),
+            It.IsAny<string?>(), "compose_project", "proj", null, null), Times.Once);
+    }
+
+    [Fact]
+    public async Task LogHistory_ServiceFilter_ExcludesOtherServices()
+    {
+        var controller = Build();
+        _containerLogService.Setup(l => l.ListProjectContainerIdsAsync("proj", true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { "a", "b" });
+        _containerLogService.Setup(l => l.GetLogSourceAsync("a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Lighthouse.Services.LogStreaming.ContainerLogSource("a", "a", "proj", "web", false));
+        _containerLogService.Setup(l => l.GetLogSourceAsync("b", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Lighthouse.Services.LogStreaming.ContainerLogSource("b", "b", "proj", "db", false));
+        _containerLogService.Setup(l => l.GetHistoryAsync(
+                It.Is<Lighthouse.Services.LogStreaming.ContainerLogSource>(s => s.Id == "a"), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LogPageDto(new List<LogEntryDto> { new("2026-07-04T12:00:00.000000000Z", "a", "a", "web", "stdout", "a1") }, false));
+
+        var result = await controller.GetProjectLogHistory("proj", services: "web");
+
+        var page = ((result.Result as OkObjectResult)?.Value as ApiResponse<LogPageDto>)?.Data;
+        page!.Entries.Select(e => e.Message).Should().Equal("a1");
+        // 'db' service filtered out → its history is never fetched
+        _containerLogService.Verify(l => l.GetHistoryAsync(
+            It.Is<Lighthouse.Services.LogStreaming.ContainerLogSource>(s => s.Id == "b"),
+            It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/lighthouse-back/lighthouse-back.Tests/Services/DockerEventBusTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/DockerEventBusTests.cs
@@ -1,0 +1,75 @@
+using Docker.DotNet.Models;
+using FluentAssertions;
+using Lighthouse.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Lighthouse.Tests.Services;
+
+public class DockerEventBusTests
+{
+    private static Message Msg(string action) => new() { Action = action, Type = "container" };
+
+    [Fact]
+    public async Task Publish_InvokesAllSubscribers()
+    {
+        var bus = new DockerEventBus(new NullLogger<DockerEventBus>());
+        int a = 0, b = 0;
+        bus.Subscribe(_ => { a++; return Task.CompletedTask; });
+        bus.Subscribe(_ => { b++; return Task.CompletedTask; });
+
+        await bus.PublishAsync(Msg("start"));
+
+        a.Should().Be(1);
+        b.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Dispose_UnsubscribesHandler()
+    {
+        var bus = new DockerEventBus(new NullLogger<DockerEventBus>());
+        int count = 0;
+        IDisposable sub = bus.Subscribe(_ => { count++; return Task.CompletedTask; });
+
+        await bus.PublishAsync(Msg("start"));
+        sub.Dispose();
+        await bus.PublishAsync(Msg("stop"));
+
+        count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Publish_FaultingSubscriber_DoesNotAffectOthers()
+    {
+        var bus = new DockerEventBus(new NullLogger<DockerEventBus>());
+        bus.Subscribe(_ => throw new InvalidOperationException("boom"));
+        int reached = 0;
+        bus.Subscribe(_ => { reached++; return Task.CompletedTask; });
+
+        Func<Task> act = () => bus.PublishAsync(Msg("start"));
+
+        await act.Should().NotThrowAsync();
+        reached.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Publish_NoSubscribers_DoesNotThrow()
+    {
+        var bus = new DockerEventBus(new NullLogger<DockerEventBus>());
+
+        Func<Task> act = () => bus.PublishAsync(Msg("start"));
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public void DoubleDispose_IsSafe()
+    {
+        var bus = new DockerEventBus(new NullLogger<DockerEventBus>());
+        IDisposable sub = bus.Subscribe(_ => Task.CompletedTask);
+
+        sub.Dispose();
+        Action act = () => sub.Dispose();
+
+        act.Should().NotThrow();
+    }
+}

--- a/lighthouse-back/lighthouse-back.Tests/Services/DockerEventHandlerServiceTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/DockerEventHandlerServiceTests.cs
@@ -10,13 +10,15 @@ public class DockerEventHandlerServiceTests
 {
     private readonly SseConnectionManagerService _sseManager;
     private readonly CrashLoopDetectionService _crashLoopDetection;
+    private readonly DockerEventBus _eventBus;
     private readonly DockerEventHandlerService _handler;
 
     public DockerEventHandlerServiceTests()
     {
         _sseManager = new SseConnectionManagerService(new NullLogger<SseConnectionManagerService>());
         _crashLoopDetection = new CrashLoopDetectionService(new NullLogger<CrashLoopDetectionService>());
-        _handler = new DockerEventHandlerService(_sseManager, _crashLoopDetection, new NullLogger<DockerEventHandlerService>());
+        _eventBus = new DockerEventBus(new NullLogger<DockerEventBus>());
+        _handler = new DockerEventHandlerService(_sseManager, _crashLoopDetection, _eventBus, new NullLogger<DockerEventHandlerService>());
     }
 
     private SseClient AddFakeSseClient()

--- a/lighthouse-back/lighthouse-back.Tests/Services/LogStreaming/ComposeLogStreamCoordinatorTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/LogStreaming/ComposeLogStreamCoordinatorTests.cs
@@ -1,0 +1,187 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using Docker.DotNet.Models;
+using FluentAssertions;
+using Lighthouse.DTOs;
+using Lighthouse.Services;
+using Lighthouse.Services.LogStreaming;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Lighthouse.Tests.Services.LogStreaming;
+
+public class ComposeLogStreamCoordinatorTests
+{
+    private readonly Mock<IContainerLogService> _logService = new();
+    private readonly DockerEventBus _bus = new(new NullLogger<DockerEventBus>());
+
+    private ComposeLogStreamCoordinator Build() =>
+        new(_logService.Object, _bus, new NullLogger<ComposeLogStreamCoordinator>());
+
+    private static ContainerLogSource Source(string id, string service) =>
+        new(id, id, "proj", service, Tty: false);
+
+    private static LogEntryDto Entry(string id, string ts, string msg) =>
+        new(ts, id, id, id, "stdout", msg);
+
+    // Yields the given entries then stays open until cancelled (simulates a live follow).
+    private static async IAsyncEnumerable<LogEntryDto> LiveStream(
+        IEnumerable<LogEntryDto> entries,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        foreach (LogEntryDto e in entries)
+        {
+            yield return e;
+        }
+        await Task.Delay(Timeout.Infinite, ct);
+    }
+
+    // Yields the given entries then completes (simulates a container that stops).
+    private static async IAsyncEnumerable<LogEntryDto> FiniteStream(IEnumerable<LogEntryDto> entries)
+    {
+        foreach (LogEntryDto e in entries)
+        {
+            await Task.Yield();
+            yield return e;
+        }
+    }
+
+    private void SetupContainer(string id, string service, Func<CancellationToken, IAsyncEnumerable<LogEntryDto>> stream)
+    {
+        _logService.Setup(l => l.GetLogSourceAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Source(id, service));
+        _logService.Setup(l => l.StreamAsync(
+                It.Is<ContainerLogSource>(s => s.Id == id), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns((ContainerLogSource _, int _, string? _, CancellationToken ct) => stream(ct));
+    }
+
+    private static async Task<List<ILogStreamItem>> CollectAsync(
+        ComposeLogStreamCoordinator coordinator,
+        CancellationToken ct,
+        ConcurrentQueue<ILogStreamItem> sink)
+    {
+        try
+        {
+            await foreach (ILogStreamItem item in coordinator.StreamProjectAsync("proj", 100, null, null, ct))
+            {
+                sink.Enqueue(item);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // stream cancelled by test
+        }
+        return sink.ToList();
+    }
+
+    private static Message StartEvent(string containerId, string project) => new()
+    {
+        Action = "start",
+        Type = "container",
+        Actor = new Actor { ID = containerId, Attributes = new Dictionary<string, string>
+        {
+            ["com.docker.compose.project"] = project
+        } }
+    };
+
+    [Fact]
+    public async Task FansInFromMultipleContainers()
+    {
+        _logService.Setup(l => l.ListProjectContainerIdsAsync("proj", false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { "a", "b" });
+        SetupContainer("a", "web", ct => LiveStream(new[] { Entry("a", "2026-07-04T12:00:00.000000000Z", "a1") }, ct));
+        SetupContainer("b", "db", ct => LiveStream(new[] { Entry("b", "2026-07-04T12:00:01.000000000Z", "b1") }, ct));
+
+        var sink = new ConcurrentQueue<ILogStreamItem>();
+        using var cts = new CancellationTokenSource();
+        var task = CollectAsync(Build(), cts.Token, sink);
+
+        await Task.Delay(900);
+        cts.Cancel();
+        var items = await task;
+
+        var logs = items.OfType<LogEntryDto>().Select(e => e.Message).ToList();
+        logs.Should().Contain("a1").And.Contain("b1");
+    }
+
+    [Fact]
+    public async Task EmitsContainersSnapshotForAttachedContainers()
+    {
+        _logService.Setup(l => l.ListProjectContainerIdsAsync("proj", false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { "a" });
+        SetupContainer("a", "web", ct => LiveStream(new[] { Entry("a", "2026-07-04T12:00:00.000000000Z", "a1") }, ct));
+
+        var sink = new ConcurrentQueue<ILogStreamItem>();
+        using var cts = new CancellationTokenSource();
+        var task = CollectAsync(Build(), cts.Token, sink);
+
+        await Task.Delay(900);
+        cts.Cancel();
+        var items = await task;
+
+        items.OfType<ContainersSnapshot>().Should().NotBeEmpty();
+        items.OfType<ContainersSnapshot>().Last().Containers.Should().Contain(c => c.Id == "a" && c.Service == "web");
+    }
+
+    [Fact]
+    public async Task AttachesContainerStartedMidStream()
+    {
+        _logService.Setup(l => l.ListProjectContainerIdsAsync("proj", false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<string>());
+        SetupContainer("late", "worker", ct => LiveStream(new[] { Entry("late", "2026-07-04T12:00:05.000000000Z", "late1") }, ct));
+
+        var sink = new ConcurrentQueue<ILogStreamItem>();
+        using var cts = new CancellationTokenSource();
+        var task = CollectAsync(Build(), cts.Token, sink);
+
+        await Task.Delay(700); // let warmup pass
+        await _bus.PublishAsync(StartEvent("late", "proj"));
+        await Task.Delay(400);
+        cts.Cancel();
+        var items = await task;
+
+        items.OfType<LogEntryDto>().Should().Contain(e => e.Message == "late1");
+    }
+
+    [Fact]
+    public async Task IgnoresStartEventsFromOtherProjects()
+    {
+        _logService.Setup(l => l.ListProjectContainerIdsAsync("proj", false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<string>());
+        SetupContainer("other", "x", ct => LiveStream(new[] { Entry("other", "2026-07-04T12:00:05.000000000Z", "nope") }, ct));
+
+        var sink = new ConcurrentQueue<ILogStreamItem>();
+        using var cts = new CancellationTokenSource();
+        var task = CollectAsync(Build(), cts.Token, sink);
+
+        await Task.Delay(700);
+        await _bus.PublishAsync(StartEvent("other", "different-project"));
+        await Task.Delay(300);
+        cts.Cancel();
+        var items = await task;
+
+        items.OfType<LogEntryDto>().Should().NotContain(e => e.Message == "nope");
+        _logService.Verify(l => l.StreamAsync(It.Is<ContainerLogSource>(s => s.Id == "other"),
+            It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DetachesWhenContainerStreamCompletes()
+    {
+        _logService.Setup(l => l.ListProjectContainerIdsAsync("proj", false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { "gone" });
+        // Finite stream → the pump completes → the container detaches.
+        SetupContainer("gone", "web", _ => FiniteStream(new[] { Entry("gone", "2026-07-04T12:00:00.000000000Z", "bye") }));
+
+        var sink = new ConcurrentQueue<ILogStreamItem>();
+        using var cts = new CancellationTokenSource();
+        var task = CollectAsync(Build(), cts.Token, sink);
+
+        await Task.Delay(900);
+        cts.Cancel();
+        var items = await task;
+
+        // Last roster must no longer contain the finished container.
+        items.OfType<ContainersSnapshot>().Last().Containers.Should().NotContain(c => c.Id == "gone");
+    }
+}

--- a/lighthouse-back/lighthouse-back.Tests/Services/LogStreaming/LogMergerTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/LogStreaming/LogMergerTests.cs
@@ -1,0 +1,108 @@
+using FluentAssertions;
+using Lighthouse.DTOs;
+using Lighthouse.Services.LogStreaming;
+
+namespace Lighthouse.Tests.Services.LogStreaming;
+
+public class LogMergerTests
+{
+    private static LogEntryDto Entry(string ts, string containerId, string msg) =>
+        new(ts, containerId, containerId, containerId, "stdout", msg);
+
+    private static LogPageDto Page(bool hasMore, params LogEntryDto[] entries) =>
+        new(entries.ToList(), hasMore);
+
+    [Fact]
+    public void MergeTail_InterleavesByTimestamp()
+    {
+        var a = Page(false,
+            Entry("2026-07-04T12:00:00.000000000Z", "a", "a1"),
+            Entry("2026-07-04T12:00:02.000000000Z", "a", "a2"));
+        var b = Page(false,
+            Entry("2026-07-04T12:00:01.000000000Z", "b", "b1"),
+            Entry("2026-07-04T12:00:03.000000000Z", "b", "b2"));
+
+        var result = LogMerger.MergeTail(new[] { a, b }, pageSize: 10);
+
+        result.Entries.Select(e => e.Message).Should().Equal("a1", "b1", "a2", "b2");
+        result.HasMore.Should().BeFalse();
+    }
+
+    [Fact]
+    public void MergeTail_KeepsNewestWhenTruncated()
+    {
+        var a = Page(false,
+            Entry("2026-07-04T12:00:00.000000000Z", "a", "old"),
+            Entry("2026-07-04T12:00:02.000000000Z", "a", "mid"));
+        var b = Page(false,
+            Entry("2026-07-04T12:00:03.000000000Z", "b", "new"));
+
+        var result = LogMerger.MergeTail(new[] { a, b }, pageSize: 2);
+
+        result.Entries.Select(e => e.Message).Should().Equal("mid", "new");
+        result.HasMore.Should().BeTrue(); // truncation implies more history
+    }
+
+    [Fact]
+    public void MergeTail_PropagatesInputHasMore()
+    {
+        var a = Page(hasMore: true, Entry("2026-07-04T12:00:00.000000000Z", "a", "a1"));
+
+        var result = LogMerger.MergeTail(new[] { a }, pageSize: 10);
+
+        result.HasMore.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MergeTail_EmptyInput_ReturnsEmpty()
+    {
+        var result = LogMerger.MergeTail(Array.Empty<LogPageDto>(), pageSize: 10);
+
+        result.Entries.Should().BeEmpty();
+        result.HasMore.Should().BeFalse();
+    }
+
+    [Fact]
+    public void MergeTail_SingleContainer_PassesThrough()
+    {
+        var a = Page(false,
+            Entry("2026-07-04T12:00:00.000000000Z", "a", "a1"),
+            Entry("2026-07-04T12:00:01.000000000Z", "a", "a2"));
+
+        var result = LogMerger.MergeTail(new[] { a }, pageSize: 10);
+
+        result.Entries.Select(e => e.Message).Should().Equal("a1", "a2");
+    }
+
+    [Fact]
+    public void MergeTail_IdenticalTimestamps_AreStableByContainerId()
+    {
+        const string ts = "2026-07-04T12:00:00.000000000Z";
+        var b = Page(false, Entry(ts, "b", "fromB"));
+        var a = Page(false, Entry(ts, "a", "fromA"));
+
+        var result = LogMerger.MergeTail(new[] { b, a }, pageSize: 10);
+
+        // tie-break by container id → 'a' before 'b' regardless of input order
+        result.Entries.Select(e => e.Message).Should().Equal("fromA", "fromB");
+    }
+
+    [Fact]
+    public void MergeTail_ChattyContainerDoesNotStarveOthersFromHasMore()
+    {
+        // 'a' is chatty and its window was full (hasMore); after truncation the merged
+        // page must report HasMore so the caller keeps paginating.
+        var a = Page(hasMore: true,
+            Entry("2026-07-04T12:00:05.000000000Z", "a", "a1"),
+            Entry("2026-07-04T12:00:06.000000000Z", "a", "a2"),
+            Entry("2026-07-04T12:00:07.000000000Z", "a", "a3"));
+        var b = Page(false,
+            Entry("2026-07-04T12:00:00.000000000Z", "b", "b_old"));
+
+        var result = LogMerger.MergeTail(new[] { a, b }, pageSize: 2);
+
+        result.Entries.Should().HaveCount(2);
+        result.Entries.Last().Message.Should().Be("a3");
+        result.HasMore.Should().BeTrue();
+    }
+}

--- a/lighthouse-back/lighthouse-back/src/Controllers/ComposeController.cs
+++ b/lighthouse-back/lighthouse-back/src/Controllers/ComposeController.cs
@@ -1,8 +1,10 @@
+using Docker.DotNet;
 using Lighthouse.Configuration;
 using Lighthouse.Data;
 using Lighthouse.DTOs;
 using Lighthouse.Models;
 using Lighthouse.Services;
+using Lighthouse.Services.LogStreaming;
 using Lighthouse.Utils;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Timeouts;
@@ -26,6 +28,8 @@ public class ComposeController : BaseController
     private readonly IComposeFileCacheService _composeFileCacheService;
     private readonly IImageUpdateCacheService _imageUpdateCacheService;
     private readonly ISelfFilterService _selfFilterService;
+    private readonly IContainerLogService _containerLogService;
+    private readonly ComposeLogStreamCoordinator _logStreamCoordinator;
 
     public ComposeController(
         IComposeDiscoveryService discoveryService,
@@ -37,7 +41,9 @@ public class ComposeController : BaseController
         IProjectMatchingService projectMatchingService,
         IComposeFileCacheService composeFileCacheService,
         IImageUpdateCacheService imageUpdateCacheService,
-        ISelfFilterService selfFilterService)
+        ISelfFilterService selfFilterService,
+        IContainerLogService containerLogService,
+        ComposeLogStreamCoordinator logStreamCoordinator)
     {
         _discoveryService = discoveryService;
         _operationService = operationService;
@@ -49,6 +55,8 @@ public class ComposeController : BaseController
         _composeFileCacheService = composeFileCacheService;
         _imageUpdateCacheService = imageUpdateCacheService;
         _selfFilterService = selfFilterService;
+        _containerLogService = containerLogService;
+        _logStreamCoordinator = logStreamCoordinator;
     }
 
     // ============================================
@@ -635,6 +643,185 @@ volumes:
         }
 
         return (userId.Value, null);
+    }
+
+    /// <summary>
+    /// Guards the read-only log endpoints: self-protection, authentication and the
+    /// project-level Logs permission. Generic over the endpoint's response type.
+    /// </summary>
+    private async Task<(int UserId, ActionResult<ApiResponse<T>>? Error)> AuthorizeProjectLogsAsync<T>(string projectName)
+    {
+        if (await _selfFilterService.IsSelfProjectAsync(projectName))
+        {
+            return (0, StatusCode(403, ApiResponse.Fail<T>(
+                "This project belongs to the application itself and cannot be accessed",
+                "SELF_PROJECT_PROTECTED")));
+        }
+
+        int? userId = GetCurrentUserId();
+        if (!userId.HasValue)
+        {
+            return (0, Unauthorized(ApiResponse.Fail<T>("User not authenticated")));
+        }
+
+        bool hasPermission = await _permissionService.HasPermissionAsync(
+            userId.Value, ResourceType.ComposeProject, projectName, PermissionFlags.Logs);
+        if (!hasPermission)
+        {
+            return (0, StatusCode(403, ApiResponse.Fail<T>(
+                "You don't have permission to view logs for this compose project",
+                "PERMISSION_DENIED")));
+        }
+
+        return (userId.Value, null);
+    }
+
+    private static HashSet<string>? ParseServiceFilter(string? services) =>
+        string.IsNullOrWhiteSpace(services)
+            ? null
+            : services.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToHashSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Returns one merged, timestamp-ordered page of historical logs across all of the
+    /// project's containers (including stopped ones), for infinite scroll-up pagination.
+    /// </summary>
+    [HttpGet("projects/{projectName}/logs/history")]
+    [ProducesResponseType(typeof(ApiResponse<LogPageDto>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ApiResponse<LogPageDto>>> GetProjectLogHistory(
+        string projectName,
+        [FromQuery] int tail = 100,
+        [FromQuery] string? until = null,
+        [FromQuery] string? services = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            projectName = Uri.UnescapeDataString(projectName);
+            tail = Math.Clamp(tail, 1, 1000);
+
+            var (userId, error) = await AuthorizeProjectLogsAsync<LogPageDto>(projectName);
+            if (error != null) return error;
+
+            HashSet<string>? serviceFilter = ParseServiceFilter(services);
+
+            IReadOnlyList<string> containerIds =
+                await _containerLogService.ListProjectContainerIdsAsync(projectName, includeStopped: true, cancellationToken);
+
+            LogPageDto?[] pages = await Task.WhenAll(containerIds.Select(async id =>
+            {
+                ContainerLogSource? source = await _containerLogService.GetLogSourceAsync(id, cancellationToken);
+                if (source == null)
+                {
+                    return null;
+                }
+                if (serviceFilter is { Count: > 0 } && (source.Service == null || !serviceFilter.Contains(source.Service)))
+                {
+                    return null;
+                }
+                try
+                {
+                    return await _containerLogService.GetHistoryAsync(source, tail, until, cancellationToken);
+                }
+                catch (DockerContainerNotFoundException)
+                {
+                    // Container removed between listing and fetch — skip it.
+                    return null;
+                }
+            }));
+
+            LogPageDto merged = LogMerger.MergeTail(pages.Where(p => p != null).Cast<LogPageDto>().ToList(), tail);
+
+            await _auditService.LogActionAsync(
+                userId, AuditActions.ComposeLogs, GetUserIpAddress(),
+                $"Viewed logs for project: {projectName}",
+                resourceType: "compose_project", resourceId: projectName);
+
+            return Ok(ApiResponse.Ok(merged, $"Retrieved {merged.Entries.Count} log lines"));
+        }
+        catch (FormatException)
+        {
+            return BadRequest(ApiResponse.Fail<LogPageDto>("Invalid 'until' timestamp", "VALIDATION_ERROR"));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving log history for project: {ProjectName}", projectName);
+            return StatusCode(500, ApiResponse.Fail<LogPageDto>("Failed to retrieve project logs", "SERVER_ERROR"));
+        }
+    }
+
+    /// <summary>
+    /// Streams the unified, real-time logs of every container in the project via SSE.
+    /// Events: connected, logs (batched JSON), containers (roster on attach/detach),
+    /// error. Containers starting/stopping mid-stream attach/detach automatically.
+    /// </summary>
+    [HttpGet("projects/{projectName}/logs/stream")]
+    public async Task StreamProjectLogs(
+        string projectName,
+        [FromQuery] int tail = 150,
+        [FromQuery] string? since = null,
+        [FromQuery] string? services = null,
+        CancellationToken cancellationToken = default)
+    {
+        projectName = Uri.UnescapeDataString(projectName);
+        tail = Math.Clamp(tail, 1, 1000);
+
+        if (await _selfFilterService.IsSelfProjectAsync(projectName))
+        {
+            Response.StatusCode = 403;
+            await Response.WriteAsJsonAsync(ApiResponse.Fail<object>(
+                "This project belongs to the application itself and cannot be accessed",
+                "SELF_PROJECT_PROTECTED"), cancellationToken);
+            return;
+        }
+
+        int? userId = GetCurrentUserId();
+        if (!userId.HasValue)
+        {
+            Response.StatusCode = 401;
+            await Response.WriteAsJsonAsync(ApiResponse.Fail<object>(
+                "User not authenticated", "UNAUTHORIZED"), cancellationToken);
+            return;
+        }
+
+        bool hasPermission = await _permissionService.HasPermissionAsync(
+            userId.Value, ResourceType.ComposeProject, projectName, PermissionFlags.Logs);
+        if (!hasPermission)
+        {
+            Response.StatusCode = 403;
+            await Response.WriteAsJsonAsync(ApiResponse.Fail<object>(
+                "You don't have permission to view logs for this compose project",
+                "PERMISSION_DENIED"), cancellationToken);
+            return;
+        }
+
+        if (since != null)
+        {
+            try
+            {
+                LogTimestampUtil.ToUnixNano(since);
+            }
+            catch (FormatException)
+            {
+                Response.StatusCode = 400;
+                await Response.WriteAsJsonAsync(ApiResponse.Fail<object>(
+                    "Invalid 'since' timestamp", "VALIDATION_ERROR"), cancellationToken);
+                return;
+            }
+        }
+
+        await _auditService.LogActionAsync(
+            userId.Value, AuditActions.ComposeLogs, GetUserIpAddress(),
+            $"Streaming logs for project: {projectName}",
+            resourceType: "compose_project", resourceId: projectName);
+
+        HashSet<string>? serviceFilter = ParseServiceFilter(services);
+
+        await SseLogStreamWriter.RunAsync(
+            HttpContext,
+            _logStreamCoordinator.StreamProjectAsync(projectName, tail, since, serviceFilter, cancellationToken),
+            _logger,
+            cancellationToken);
     }
 
     /// <summary>

--- a/lighthouse-back/lighthouse-back/src/DTOs/ComposeDtos.cs
+++ b/lighthouse-back/lighthouse-back/src/DTOs/ComposeDtos.cs
@@ -163,37 +163,6 @@ public record ComposeTemplateDto(
 );
 
 // ============================================
-// Compose Logs DTOs
-// ============================================
-
-/// <summary>
-/// Request for compose logs
-/// </summary>
-public record ComposeLogsRequest(
-    string? ServiceName = null,
-    int? Tail = 100,
-    bool Follow = false
-);
-
-/// <summary>
-/// Compose logs response
-/// </summary>
-public record ComposeLogsResponse(
-    List<ComposeLogEntry> Logs,
-    string ProjectName
-);
-
-/// <summary>
-/// Single log entry
-/// </summary>
-public record ComposeLogEntry(
-    string ServiceName,
-    string Timestamp,
-    string Message,
-    string Level // info, warning, error
-);
-
-// ============================================
 // Compose Path DTOs
 // ============================================
 

--- a/lighthouse-back/lighthouse-back/src/DTOs/LogDtos.cs
+++ b/lighthouse-back/lighthouse-back/src/DTOs/LogDtos.cs
@@ -1,6 +1,14 @@
 namespace Lighthouse.DTOs;
 
 /// <summary>
+/// Marker for anything that can be written to a log SSE stream, so log lines and
+/// out-of-band control frames (e.g. the compose container roster) can flow through a
+/// single ordered channel and a single writer — avoiding concurrent writes to the
+/// same HTTP response.
+/// </summary>
+public interface ILogStreamItem { }
+
+/// <summary>
 /// A single structured log line from a container.
 /// </summary>
 /// <param name="Timestamp">
@@ -20,9 +28,21 @@ public record LogEntryDto(
     string ContainerName,
     string? Service,
     string Stream,
-    string Message);
+    string Message) : ILogStreamItem;
 
 /// <summary>
 /// One page of historical logs. Entries are sorted ascending by timestamp.
 /// </summary>
 public record LogPageDto(List<LogEntryDto> Entries, bool HasMore);
+
+/// <summary>
+/// A container currently attached to a compose log stream (drives the frontend's
+/// per-container filter chips).
+/// </summary>
+public record AttachedContainerDto(string Id, string Name, string? Service, string State);
+
+/// <summary>
+/// Full roster of containers attached to a compose log stream, re-sent whenever a
+/// container attaches or detaches.
+/// </summary>
+public record ContainersSnapshot(List<AttachedContainerDto> Containers) : ILogStreamItem;

--- a/lighthouse-back/lighthouse-back/src/Extensions/ServiceCollectionExtensions.cs
+++ b/lighthouse-back/lighthouse-back/src/Extensions/ServiceCollectionExtensions.cs
@@ -48,6 +48,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<DockerService>();
         services.AddSingleton<IDockerImageOperations>(sp => sp.GetRequiredService<DockerService>());
         services.AddSingleton<IContainerLogService, ContainerLogService>();
+        services.AddTransient<ComposeLogStreamCoordinator>();
         services.AddScoped<IImageService, ImageService>();
         services.AddScoped<IRegistryCredentialService, RegistryCredentialService>();
         return services;
@@ -132,6 +133,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton<SseConnectionManagerService>();
         services.AddSingleton<CrashLoopDetectionService>();
+        services.AddSingleton<IDockerEventBus, DockerEventBus>();
         services.AddSingleton<DockerEventHandlerService>();
         return services;
     }

--- a/lighthouse-back/lighthouse-back/src/Services/DockerEventBus.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/DockerEventBus.cs
@@ -1,0 +1,64 @@
+using System.Collections.Concurrent;
+using Docker.DotNet.Models;
+
+namespace Lighthouse.Services;
+
+/// <inheritdoc cref="IDockerEventBus" />
+public class DockerEventBus : IDockerEventBus
+{
+    private readonly ConcurrentDictionary<Guid, Func<Message, Task>> _subscribers = new();
+    private readonly ILogger<DockerEventBus> _logger;
+
+    public DockerEventBus(ILogger<DockerEventBus> logger)
+    {
+        _logger = logger;
+    }
+
+    public IDisposable Subscribe(Func<Message, Task> handler)
+    {
+        Guid id = Guid.NewGuid();
+        _subscribers[id] = handler;
+        return new Subscription(this, id);
+    }
+
+    public async Task PublishAsync(Message message)
+    {
+        foreach (KeyValuePair<Guid, Func<Message, Task>> subscriber in _subscribers)
+        {
+            try
+            {
+                await subscriber.Value(message);
+            }
+            catch (Exception ex)
+            {
+                // Isolate a faulting subscriber so it cannot break delivery to the others.
+                _logger.LogError(ex, "Docker event subscriber threw while handling action {Action}", message.Action);
+            }
+        }
+    }
+
+    private void Unsubscribe(Guid id) => _subscribers.TryRemove(id, out _);
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly DockerEventBus _bus;
+        private readonly Guid _id;
+        private bool _disposed;
+
+        public Subscription(DockerEventBus bus, Guid id)
+        {
+            _bus = bus;
+            _id = id;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+            _bus.Unsubscribe(_id);
+        }
+    }
+}

--- a/lighthouse-back/lighthouse-back/src/Services/DockerEventHandlerService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/DockerEventHandlerService.cs
@@ -10,6 +10,7 @@ public class DockerEventHandlerService
 {
     private readonly SseConnectionManagerService _sseManager;
     private readonly CrashLoopDetectionService _crashLoopDetection;
+    private readonly IDockerEventBus _eventBus;
     private readonly ILogger<DockerEventHandlerService> _logger;
 
     private static readonly string[] RelevantActions =
@@ -21,10 +22,12 @@ public class DockerEventHandlerService
     public DockerEventHandlerService(
         SseConnectionManagerService sseManager,
         CrashLoopDetectionService crashLoopDetection,
+        IDockerEventBus eventBus,
         ILogger<DockerEventHandlerService> logger)
     {
         _sseManager = sseManager;
         _crashLoopDetection = crashLoopDetection;
+        _eventBus = eventBus;
         _logger = logger;
     }
 
@@ -63,6 +66,10 @@ public class DockerEventHandlerService
         // Record event for crash loop detection
         _crashLoopDetection.RecordEvent(containerId, message.Action);
         bool isCrashLooping = _crashLoopDetection.IsContainerCrashLooping(containerId);
+
+        // Fan out the raw event to in-process consumers (e.g. compose log coordinators
+        // that attach/detach per-container follow streams as containers come and go).
+        await _eventBus.PublishAsync(message);
 
         // Broadcast container state change to all connected SSE clients
         await _sseManager.BroadcastAsync("ContainerStateChanged", new

--- a/lighthouse-back/lighthouse-back/src/Services/IDockerEventBus.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/IDockerEventBus.cs
@@ -1,0 +1,23 @@
+using Docker.DotNet.Models;
+
+namespace Lighthouse.Services;
+
+/// <summary>
+/// In-process fan-out of raw Docker container events. Lets multiple in-process
+/// consumers (e.g. per-request compose log coordinators) react to container
+/// start/stop without each opening its own Docker event stream.
+/// </summary>
+public interface IDockerEventBus
+{
+    /// <summary>
+    /// Registers a handler invoked for every published container event.
+    /// Dispose the returned token to unsubscribe.
+    /// </summary>
+    IDisposable Subscribe(Func<Message, Task> handler);
+
+    /// <summary>
+    /// Publishes an event to all current subscribers. Never throws; a faulting
+    /// subscriber is isolated and does not affect the others.
+    /// </summary>
+    Task PublishAsync(Message message);
+}

--- a/lighthouse-back/lighthouse-back/src/Services/LogStreaming/ComposeLogStreamCoordinator.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/LogStreaming/ComposeLogStreamCoordinator.cs
@@ -1,0 +1,185 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Docker.DotNet.Models;
+using Lighthouse.DTOs;
+
+namespace Lighthouse.Services.LogStreaming;
+
+/// <summary>
+/// Fans in the live log streams of every container in a compose project into a single
+/// ordered sequence, and keeps the set of attached containers current as they start and
+/// stop. One instance per SSE request.
+/// </summary>
+public class ComposeLogStreamCoordinator
+{
+    private static readonly TimeSpan WarmupWindow = TimeSpan.FromMilliseconds(500);
+    private const int ChannelCapacity = 10_000;
+
+    private readonly IContainerLogService _logService;
+    private readonly IDockerEventBus _eventBus;
+    private readonly ILogger<ComposeLogStreamCoordinator> _logger;
+
+    public ComposeLogStreamCoordinator(
+        IContainerLogService logService,
+        IDockerEventBus eventBus,
+        ILogger<ComposeLogStreamCoordinator> logger)
+    {
+        _logService = logService;
+        _eventBus = eventBus;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Streams the project's logs as <see cref="LogEntryDto"/> items interleaved with
+    /// <see cref="ContainersSnapshot"/> control frames (emitted on every attach/detach).
+    /// Optionally restricts to the given services. When <paramref name="since"/> is set,
+    /// each container resumes from that timestamp instead of replaying its tail.
+    /// </summary>
+    public async IAsyncEnumerable<ILogStreamItem> StreamProjectAsync(
+        string projectName,
+        int tailPerContainer,
+        string? since,
+        IReadOnlySet<string>? services,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        Channel<ILogStreamItem> channel = Channel.CreateBounded<ILogStreamItem>(
+            new BoundedChannelOptions(ChannelCapacity) { FullMode = BoundedChannelFullMode.Wait });
+
+        var attached = new ConcurrentDictionary<string, AttachedContainerDto>();
+        var pumping = new ConcurrentDictionary<string, byte>();
+
+        void EmitSnapshot()
+        {
+            var roster = attached.Values.OrderBy(c => c.Name, StringComparer.Ordinal).ToList();
+            channel.Writer.TryWrite(new ContainersSnapshot(roster));
+        }
+
+        bool ServiceAllowed(string? service) =>
+            services == null || services.Count == 0 || (service != null && services.Contains(service));
+
+        async Task AttachAsync(string containerId, int tail, string? pumpSince)
+        {
+            ContainerLogSource? source;
+            try
+            {
+                source = await _logService.GetLogSourceAsync(containerId, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to resolve log source for container {ContainerId}", containerId);
+                return;
+            }
+
+            if (source == null || !ServiceAllowed(source.Service))
+            {
+                return;
+            }
+            if (!pumping.TryAdd(source.Id, 0))
+            {
+                return; // already streaming this container
+            }
+
+            attached[source.Id] = new AttachedContainerDto(source.Id, source.Name, source.Service, "running");
+            EmitSnapshot();
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await foreach (LogEntryDto entry in _logService.StreamAsync(source, tail, pumpSince, ct))
+                    {
+                        await channel.Writer.WriteAsync(entry, ct);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // request ended
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Log pump for container {ContainerId} ended with error", source.Id);
+                }
+                finally
+                {
+                    pumping.TryRemove(source.Id, out _);
+                    attached.TryRemove(source.Id, out _);
+                    EmitSnapshot();
+                }
+            }, ct);
+        }
+
+        // Attach a container that starts mid-stream (resume from now, no tail replay).
+        using IDisposable subscription = _eventBus.Subscribe(async message =>
+        {
+            if (message.Action != "start" || message.Actor?.Attributes == null)
+            {
+                return;
+            }
+            if (!message.Actor.Attributes.TryGetValue("com.docker.compose.project", out string? project) ||
+                !string.Equals(project, projectName, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+            await AttachAsync(message.Actor.ID, tail: 0, pumpSince: Rfc3339Now());
+        });
+
+        // Attach the containers already running when the stream opens.
+        IReadOnlyList<string> running = await _logService.ListProjectContainerIdsAsync(projectName, includeStopped: false, ct);
+        foreach (string containerId in running)
+        {
+            await AttachAsync(containerId, tailPerContainer, since);
+        }
+
+        await foreach (ILogStreamItem item in ReadWithWarmupAsync(channel.Reader, ct))
+        {
+            yield return item;
+        }
+    }
+
+    /// <summary>
+    /// Reorders the initial burst (the per-container tail bursts arrive interleaved)
+    /// within a short window, then passes everything through live. Log items are sorted
+    /// by timestamp; container snapshots keep their arrival order.
+    /// </summary>
+    private static async IAsyncEnumerable<ILogStreamItem> ReadWithWarmupAsync(
+        ChannelReader<ILogStreamItem> reader,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        var warmup = new List<ILogStreamItem>();
+        using (var warmupCts = CancellationTokenSource.CreateLinkedTokenSource(ct))
+        {
+            warmupCts.CancelAfter(WarmupWindow);
+            try
+            {
+                await foreach (ILogStreamItem item in reader.ReadAllAsync(warmupCts.Token))
+                {
+                    warmup.Add(item);
+                }
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                // warmup window elapsed
+            }
+        }
+
+        // Stable sort: container snapshots (empty key) lead, then log entries by
+        // timestamp; OrderBy preserves arrival order for equal keys.
+        IEnumerable<ILogStreamItem> ordered = warmup.OrderBy(
+            item => item is LogEntryDto entry ? entry.Timestamp : string.Empty,
+            StringComparer.Ordinal);
+
+        foreach (ILogStreamItem item in ordered)
+        {
+            yield return item;
+        }
+
+        await foreach (ILogStreamItem item in reader.ReadAllAsync(ct))
+        {
+            yield return item;
+        }
+    }
+
+    private static string Rfc3339Now() =>
+        DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffffff'Z'");
+}

--- a/lighthouse-back/lighthouse-back/src/Services/LogStreaming/ContainerLogService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/LogStreaming/ContainerLogService.cs
@@ -56,6 +56,21 @@ public class ContainerLogService : IContainerLogService, IDisposable
         }
     }
 
+    public async Task<IReadOnlyList<string>> ListProjectContainerIdsAsync(string projectName, bool includeStopped, CancellationToken ct = default)
+    {
+        var parameters = new ContainersListParameters
+        {
+            All = includeStopped,
+            Filters = new Dictionary<string, IDictionary<string, bool>>
+            {
+                ["label"] = new Dictionary<string, bool> { [$"{ComposeProjectLabel}={projectName}"] = true }
+            }
+        };
+
+        IList<ContainerListResponse> containers = await _dockerClient.Containers.ListContainersAsync(parameters, ct);
+        return containers.Select(c => c.ID).ToList();
+    }
+
     public async Task<LogPageDto> GetHistoryAsync(ContainerLogSource source, int tail, string? until, CancellationToken ct = default)
     {
         ContainerLogsParameters parameters = new()

--- a/lighthouse-back/lighthouse-back/src/Services/LogStreaming/IContainerLogService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/LogStreaming/IContainerLogService.cs
@@ -24,6 +24,13 @@ public interface IContainerLogService
     Task<ContainerLogSource?> GetLogSourceAsync(string containerId, CancellationToken ct = default);
 
     /// <summary>
+    /// Lists the container IDs belonging to a compose project (via the
+    /// com.docker.compose.project label). When <paramref name="includeStopped"/> is
+    /// true, stopped containers are included (their historical logs still exist).
+    /// </summary>
+    Task<IReadOnlyList<string>> ListProjectContainerIdsAsync(string projectName, bool includeStopped, CancellationToken ct = default);
+
+    /// <summary>
     /// Fetches one page of historical logs, ascending by timestamp.
     /// <paramref name="until"/> is an RFC3339Nano cursor (exclusive-ish: Docker treats
     /// it inclusively, callers dedup the boundary); null means "up to now".

--- a/lighthouse-back/lighthouse-back/src/Services/LogStreaming/LogMerger.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/LogStreaming/LogMerger.cs
@@ -1,0 +1,49 @@
+using Lighthouse.DTOs;
+
+namespace Lighthouse.Services.LogStreaming;
+
+/// <summary>
+/// Merges per-container history pages into one project-wide page, ordered by timestamp.
+/// </summary>
+public static class LogMerger
+{
+    /// <summary>
+    /// K-way merges the given per-container pages and keeps the newest
+    /// <paramref name="pageSize"/> entries, returned ascending by timestamp
+    /// (tie-broken by container id for a stable order).
+    /// </summary>
+    /// <remarks>
+    /// Gap-free by construction: each input page was fetched with a full tail window,
+    /// so a container that still has older un-fetched entries necessarily filled its
+    /// window — its oldest fetched entry therefore bounds the merged page's oldest,
+    /// and the next <c>until</c> cursor cannot skip anything.
+    /// Timestamps are compared as strings: Docker emits fixed-width RFC3339Nano in UTC,
+    /// so lexical order equals chronological order.
+    /// </remarks>
+    public static LogPageDto MergeTail(IReadOnlyList<LogPageDto> perContainer, int pageSize)
+    {
+        List<LogEntryDto> all = new();
+        bool anyInputHasMore = false;
+
+        foreach (LogPageDto page in perContainer)
+        {
+            all.AddRange(page.Entries);
+            anyInputHasMore |= page.HasMore;
+        }
+
+        all.Sort(CompareEntries);
+
+        bool truncated = all.Count > pageSize;
+        List<LogEntryDto> window = truncated
+            ? all.GetRange(all.Count - pageSize, pageSize)
+            : all;
+
+        return new LogPageDto(window, HasMore: anyInputHasMore || truncated);
+    }
+
+    private static int CompareEntries(LogEntryDto a, LogEntryDto b)
+    {
+        int byTimestamp = string.CompareOrdinal(a.Timestamp, b.Timestamp);
+        return byTimestamp != 0 ? byTimestamp : string.CompareOrdinal(a.ContainerId, b.ContainerId);
+    }
+}

--- a/lighthouse-back/lighthouse-back/src/Services/LogStreaming/SseLogStreamWriter.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/LogStreaming/SseLogStreamWriter.cs
@@ -23,7 +23,7 @@ public static class SseLogStreamWriter
 
     public static async Task RunAsync(
         HttpContext httpContext,
-        IAsyncEnumerable<LogEntryDto> entries,
+        IAsyncEnumerable<ILogStreamItem> items,
         ILogger logger,
         CancellationToken ct)
     {
@@ -42,14 +42,14 @@ public static class SseLogStreamWriter
             await WriteEventAsync(response, "connected",
                 JsonSerializer.Serialize(new { streamId = Guid.NewGuid().ToString() }, JsonOptions), ct);
 
-            Channel<LogEntryDto> channel = Channel.CreateBounded<LogEntryDto>(new BoundedChannelOptions(ChannelCapacity)
+            Channel<ILogStreamItem> channel = Channel.CreateBounded<ILogStreamItem>(new BoundedChannelOptions(ChannelCapacity)
             {
                 SingleReader = true,
                 SingleWriter = true,
                 FullMode = BoundedChannelFullMode.Wait
             });
 
-            Task producer = PumpAsync(entries, channel.Writer, ct);
+            Task producer = PumpAsync(items, channel.Writer, ct);
             await ConsumeAsync(response, channel.Reader, ct);
             await producer;
         }
@@ -74,15 +74,15 @@ public static class SseLogStreamWriter
     }
 
     private static async Task PumpAsync(
-        IAsyncEnumerable<LogEntryDto> entries,
-        ChannelWriter<LogEntryDto> writer,
+        IAsyncEnumerable<ILogStreamItem> items,
+        ChannelWriter<ILogStreamItem> writer,
         CancellationToken ct)
     {
         try
         {
-            await foreach (LogEntryDto entry in entries.WithCancellation(ct))
+            await foreach (ILogStreamItem item in items.WithCancellation(ct))
             {
-                await writer.WriteAsync(entry, ct);
+                await writer.WriteAsync(item, ct);
             }
             writer.Complete();
         }
@@ -94,10 +94,11 @@ public static class SseLogStreamWriter
 
     private static async Task ConsumeAsync(
         HttpResponse response,
-        ChannelReader<LogEntryDto> reader,
+        ChannelReader<ILogStreamItem> reader,
         CancellationToken ct)
     {
         List<LogEntryDto> batch = new(MaxBatchSize);
+        List<ContainersSnapshot> snapshots = new();
         DateTime lastWrite = DateTime.UtcNow;
         DateTime? batchDeadline = null;
 
@@ -128,13 +129,22 @@ public static class SseLogStreamWriter
 
             if (!completed && !timedOut)
             {
-                while (batch.Count < MaxBatchSize && reader.TryRead(out LogEntryDto? entry))
+                while (batch.Count < MaxBatchSize && reader.TryRead(out ILogStreamItem? item))
                 {
-                    batch.Add(entry);
+                    if (item is LogEntryDto entry)
+                    {
+                        batch.Add(entry);
+                    }
+                    else if (item is ContainersSnapshot snapshot)
+                    {
+                        // Control frame: flush pending logs then emit it immediately.
+                        snapshots.Add(snapshot);
+                        break;
+                    }
                 }
                 batchDeadline ??= DateTime.UtcNow + FlushInterval;
 
-                if (batch.Count < MaxBatchSize)
+                if (snapshots.Count == 0 && batch.Count < MaxBatchSize)
                 {
                     continue; // accumulate until the flush deadline or a full batch
                 }
@@ -148,7 +158,18 @@ public static class SseLogStreamWriter
                 batchDeadline = null;
                 lastWrite = DateTime.UtcNow;
             }
-            else if (timedOut)
+
+            if (snapshots.Count > 0)
+            {
+                foreach (ContainersSnapshot snapshot in snapshots)
+                {
+                    await WriteEventAsync(response, "containers",
+                        JsonSerializer.Serialize(new { containers = snapshot.Containers }, JsonOptions), ct);
+                }
+                snapshots.Clear();
+                lastWrite = DateTime.UtcNow;
+            }
+            else if (batch.Count == 0 && timedOut)
             {
                 await response.WriteAsync(": heartbeat\n\n", ct);
                 await response.Body.FlushAsync(ct);


### PR DESCRIPTION
Part 2 of 3 for the log system re-architecture (#42). Backend only, compose-project logs. Builds on the container log services from PR1 (#181).

The compose project log view was entirely absent (no backend endpoint — the frontend showed "No container ID provided"). This adds a **unified** view: one SSE stream carrying every container's logs interleaved by timestamp, plus history pagination across the whole project.

## What's new

- **`LogMerger`** — k-way merge of per-container history pages by timestamp, keeps the newest page. Gap-free by construction; stable tie-break by container id.
- **`IDockerEventBus` / `DockerEventBus`** — in-process fan-out of Docker container events. `DockerEventHandlerService` publishes to it, so consumers react to start/stop without opening their own Docker event stream.
- **`ComposeLogStreamCoordinator`** (one per SSE request) — fans in a follow stream per running container into one ordered sequence, warmup-reorders the initial burst, and **attaches/detaches containers live** as they start/stop. Emits `containers` roster frames on every change (drives the frontend filter chips).
- **`IContainerLogService.ListProjectContainerIdsAsync`** — lists a project's containers (optionally including stopped ones, whose history still exists).
- **`SseLogStreamWriter`** now carries `ILogStreamItem`, multiplexing batched `logs` events and immediate `containers` frames through a **single** writer (no concurrent writes to the response). `LogEntryDto` implements the marker, so the PR1 container endpoint is covariantly unchanged.
- **`ComposeController`**:
  - `GET projects/{name}/logs/history?tail&until&services=` — merged, ascending, includes stopped containers, tolerates ones removed mid-request, optional service filter.
  - `GET projects/{name}/logs/stream?tail&since&services=` — SSE. Both guard self-project / auth / project-level `Logs` permission and audit via the existing `compose.logs` action.
- Removed the long-orphaned `ComposeLogsRequest/Response/Entry` DTOs.

## Tests

`LogMergerTests`, `DockerEventBusTests`, `DockerEventHandlerServiceTests` (bus wiring), `ComposeLogStreamCoordinatorTests` (fan-in, mid-stream attach, other-project isolation, detach-on-completion, service filter), and `ComposeControllerTests` log-endpoint cases (403 self / 401 / 403 no-perm / 200 merged + audit / service filter). Full backend suite green (443 passed).

## Manual verification (needs a live daemon)

- `dev-setup/sample-compose-files/demo-compose.yml`, then `curl -N ".../api/compose/projects/<name>/logs/stream?access_token=..."` → interleaved lines with per-container identity, ordered by timestamp
- `docker compose stop <svc>` / `start <svc>` mid-stream → `containers` roster frames update and lines resume
- history walk with `until` across the project → no gaps/dupes
- `services=web,db` filter narrows both endpoints
- user without project `Logs` permission → 403 on both

## Next

PR3: the frontend viewer rewrite (virtualized list, scroll-up loading, per-container badges, filter chips, text search, stdout/stderr styling, ANSI). The compose tab starts working there — this PR wires the backend it will consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)