### PR TITLE
fix(updates): route generic registry digest checks to the parsed registry host

### DIFF
--- a/lighthouse-back/lighthouse-back.Tests/Services/Registry/DockerHubRegistryClientTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/Registry/DockerHubRegistryClientTests.cs
@@ -54,7 +54,7 @@ public class DockerHubRegistryClientTests
             return RegistryResponses.NotFound();
         }, out _);
 
-        string? digest = await client.GetManifestDigestAsync("library/nginx", "latest", "amd64");
+        string? digest = await client.GetManifestDigestAsync("docker.io", "library/nginx", "latest", "amd64");
 
         digest.Should().Be("sha256:headdigest");
     }
@@ -69,7 +69,7 @@ public class DockerHubRegistryClientTests
             return RegistryResponses.Head(System.Net.HttpStatusCode.OK, "sha256:never");
         }, out _);
 
-        string? digest = await client.GetManifestDigestAsync("library/nginx", "latest", "amd64");
+        string? digest = await client.GetManifestDigestAsync("docker.io", "library/nginx", "latest", "amd64");
 
         digest.Should().BeNull();
     }
@@ -79,7 +79,7 @@ public class DockerHubRegistryClientTests
     {
         DockerHubRegistryClient client = CreateClient(_ => RegistryResponses.TooManyRequests(), out _);
 
-        Func<Task> act = () => client.GetManifestDigestAsync("library/nginx", "latest", "amd64");
+        Func<Task> act = () => client.GetManifestDigestAsync("docker.io", "library/nginx", "latest", "amd64");
 
         await act.Should().ThrowAsync<RegistryRateLimitException>();
     }
@@ -105,7 +105,7 @@ public class DockerHubRegistryClientTests
         }, out _);
 
         (string? digest, DateTime? createdAt) =
-            await client.GetManifestDigestAndCreatedAtAsync("library/nginx", "latest", "amd64");
+            await client.GetManifestDigestAndCreatedAtAsync("docker.io", "library/nginx", "latest", "amd64");
 
         digest.Should().Be("sha256:listdigest");
         createdAt.Should().Be(new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc).ToLocalTime());
@@ -128,7 +128,7 @@ public class DockerHubRegistryClientTests
         }, out _);
 
         (string? digest, DateTime? createdAt) =
-            await client.GetManifestDigestAndCreatedAtAsync("library/nginx", "latest", "amd64");
+            await client.GetManifestDigestAndCreatedAtAsync("docker.io", "library/nginx", "latest", "amd64");
 
         digest.Should().Be("sha256:singledigest");
         createdAt.Should().Be(new DateTime(2026, 5, 6, 7, 8, 9, DateTimeKind.Utc).ToLocalTime());

--- a/lighthouse-back/lighthouse-back.Tests/Services/Registry/GenericOciRegistryClientTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/Registry/GenericOciRegistryClientTests.cs
@@ -8,17 +8,23 @@ namespace Lighthouse.Tests.Services.Registry;
 
 /// <summary>
 /// Characterization tests pinning the externally observable behaviour of
-/// <see cref="GenericOciRegistryClient"/> (the fallback client; derives registry/repository
-/// from the image reference and authenticates via the WWW-Authenticate challenge).
+/// <see cref="GenericOciRegistryClient"/> (the fallback client; targets the registry host it is
+/// given and authenticates via the WWW-Authenticate challenge).
 /// </summary>
 public class GenericOciRegistryClientTests
 {
-    private const string Image = "myreg.io/owner/repo";
+    private const string Registry = "myreg.io";
+    private const string Repository = "owner/repo";
 
     private static GenericOciRegistryClient CreateClient(
         Func<HttpRequestMessage, HttpResponseMessage> responder)
+        => CreateClient(responder, out _);
+
+    private static GenericOciRegistryClient CreateClient(
+        Func<HttpRequestMessage, HttpResponseMessage> responder,
+        out FakeHttpMessageHandler handler)
     {
-        var handler = new FakeHttpMessageHandler(responder);
+        handler = new FakeHttpMessageHandler(responder);
         return new GenericOciRegistryClient(
             handler.CreateClient(),
             Options.Create(new UpdateCheckOptions { TimeoutSeconds = 30 }),
@@ -40,9 +46,27 @@ public class GenericOciRegistryClientTests
                 ? RegistryResponses.Head(System.Net.HttpStatusCode.OK, "sha256:generichead")
                 : RegistryResponses.NotFound());
 
-        string? digest = await client.GetManifestDigestAsync(Image, "latest", "amd64");
+        string? digest = await client.GetManifestDigestAsync(Registry, Repository, "latest", "amd64");
 
         digest.Should().Be("sha256:generichead");
+    }
+
+    [Fact]
+    public async Task GetManifestDigestAsync_TargetsProvidedRegistryHost()
+    {
+        // Regression: the client used to re-derive the registry from the repository string and
+        // ended up querying docker.io for images hosted on other registries (e.g. lscr.io).
+        GenericOciRegistryClient client = CreateClient(req =>
+            req.Method == HttpMethod.Head
+                ? RegistryResponses.Head(System.Net.HttpStatusCode.OK, "sha256:hosted")
+                : RegistryResponses.NotFound(),
+            out FakeHttpMessageHandler handler);
+
+        string? digest = await client.GetManifestDigestAsync("lscr.io", "linuxserver/radarr", "latest", "amd64");
+
+        digest.Should().Be("sha256:hosted");
+        handler.Requests.Should().OnlyContain(r =>
+            r.Url.StartsWith("https://lscr.io/v2/linuxserver/radarr/"));
     }
 
     [Fact]
@@ -59,15 +83,40 @@ public class GenericOciRegistryClientTests
             // Authenticated HEAD succeeds.
             if (req.Method == HttpMethod.Head)
                 return RegistryResponses.Head(System.Net.HttpStatusCode.OK, "sha256:genauthed");
-            // GET manifests/latest with no auth → 401 challenge (used by the token probe).
+            // GET manifest with no auth → 401 challenge (used by the token probe).
             if (req.Method == HttpMethod.Get && req.Headers.Authorization == null)
                 return RegistryResponses.Unauthorized("https://myreg.io/token", "myreg.io", "repository:owner/repo:pull");
             return RegistryResponses.NotFound();
         });
 
-        string? digest = await client.GetManifestDigestAsync(Image, "latest", "amd64");
+        string? digest = await client.GetManifestDigestAsync(Registry, Repository, "latest", "amd64");
 
         digest.Should().Be("sha256:genauthed");
+    }
+
+    [Fact]
+    public async Task GetManifestDigestAsync_TokenProbeUsesRequestedTag()
+    {
+        // Regression: the token probe used a hardcoded "manifests/latest" URL; registries that
+        // validate the tag before issuing the challenge would fail for repos without that tag.
+        GenericOciRegistryClient client = CreateClient(req =>
+        {
+            string url = req.RequestUri!.ToString();
+            if (url.Contains("/token"))
+                return RegistryResponses.Json("{\"token\":\"tok\"}");
+            if (url.Contains("/manifests/latest"))
+                return RegistryResponses.NotFound();
+            if (req.Headers.Authorization == null)
+                return RegistryResponses.Unauthorized("https://myreg.io/token", "myreg.io", "repository:owner/repo:pull");
+            if (req.Method == HttpMethod.Head)
+                return RegistryResponses.Head(System.Net.HttpStatusCode.OK, "sha256:taggeddigest");
+            return RegistryResponses.NotFound();
+        }, out FakeHttpMessageHandler handler);
+
+        string? digest = await client.GetManifestDigestAsync(Registry, Repository, "4.3.2", "amd64");
+
+        digest.Should().Be("sha256:taggeddigest");
+        handler.Requests.Should().NotContain(r => r.Url.Contains("/manifests/latest"));
     }
 
     [Fact]
@@ -85,7 +134,7 @@ public class GenericOciRegistryClientTests
         });
 
         (string? digest, DateTime? createdAt) =
-            await client.GetManifestDigestAndCreatedAtAsync(Image, "latest", "amd64");
+            await client.GetManifestDigestAndCreatedAtAsync(Registry, Repository, "latest", "amd64");
 
         digest.Should().Be("sha256:gensingle");
         createdAt.Should().Be(new DateTime(2026, 9, 10, 11, 12, 13, DateTimeKind.Utc).ToLocalTime());

--- a/lighthouse-back/lighthouse-back.Tests/Services/Registry/GhcrRegistryClientTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/Registry/GhcrRegistryClientTests.cs
@@ -41,7 +41,7 @@ public class GhcrRegistryClientTests
                 ? RegistryResponses.Head(System.Net.HttpStatusCode.OK, "sha256:ghcrhead")
                 : RegistryResponses.NotFound());
 
-        string? digest = await client.GetManifestDigestAsync("owner/repo", "latest", "amd64");
+        string? digest = await client.GetManifestDigestAsync("ghcr.io", "owner/repo", "latest", "amd64");
 
         digest.Should().Be("sha256:ghcrhead");
     }
@@ -61,7 +61,7 @@ public class GhcrRegistryClientTests
             return RegistryResponses.NotFound();
         });
 
-        string? digest = await client.GetManifestDigestAsync("owner/repo", "latest", "amd64");
+        string? digest = await client.GetManifestDigestAsync("ghcr.io", "owner/repo", "latest", "amd64");
 
         digest.Should().Be("sha256:authedhead");
     }
@@ -71,7 +71,7 @@ public class GhcrRegistryClientTests
     {
         GhcrRegistryClient client = CreateClient(_ => RegistryResponses.TooManyRequests());
 
-        Func<Task> act = () => client.GetManifestDigestAsync("owner/repo", "latest", "amd64");
+        Func<Task> act = () => client.GetManifestDigestAsync("ghcr.io", "owner/repo", "latest", "amd64");
 
         await act.Should().ThrowAsync<RegistryRateLimitException>();
     }
@@ -91,7 +91,7 @@ public class GhcrRegistryClientTests
         });
 
         (string? digest, DateTime? createdAt) =
-            await client.GetManifestDigestAndCreatedAtAsync("owner/repo", "latest", "amd64");
+            await client.GetManifestDigestAndCreatedAtAsync("ghcr.io", "owner/repo", "latest", "amd64");
 
         digest.Should().Be("sha256:ghcrsingle");
         createdAt.Should().Be(new DateTime(2026, 7, 8, 9, 10, 11, DateTimeKind.Utc).ToLocalTime());

--- a/lighthouse-back/lighthouse-back.Tests/Services/Registry/RegistryClientsIntegrationTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/Registry/RegistryClientsIntegrationTests.cs
@@ -45,13 +45,13 @@ public class RegistryClientsIntegrationTests
     private static GenericOciRegistryClient Generic()
         => new(new HttpClient(), Options(), new NullLogger<GenericOciRegistryClient>());
 
-    private async Task AssertResolvesAsync(IRegistryClient client, string repositoryOrImage, string tag)
+    private async Task AssertResolvesAsync(IRegistryClient client, string registry, string repository, string tag)
     {
-        string? headDigest = await client.GetManifestDigestAsync(repositoryOrImage, tag, Architecture);
+        string? headDigest = await client.GetManifestDigestAsync(registry, repository, tag, Architecture);
         (string? getDigest, DateTime? createdAt) =
-            await client.GetManifestDigestAndCreatedAtAsync(repositoryOrImage, tag, Architecture);
+            await client.GetManifestDigestAndCreatedAtAsync(registry, repository, tag, Architecture);
 
-        _output.WriteLine($"{repositoryOrImage}:{tag}");
+        _output.WriteLine($"{registry}/{repository}:{tag}");
         _output.WriteLine($"  HEAD digest : {headDigest}");
         _output.WriteLine($"  GET  digest : {getDigest}");
         _output.WriteLine($"  created at  : {createdAt:O}");
@@ -65,13 +65,17 @@ public class RegistryClientsIntegrationTests
 
     [IntegrationFact]
     public async Task DockerHub_ResolvesDigestForLibraryNginx()
-        => await AssertResolvesAsync(DockerHub(), "library/nginx", "latest");
+        => await AssertResolvesAsync(DockerHub(), "docker.io", "library/nginx", "latest");
 
     [IntegrationFact]
     public async Task Ghcr_ResolvesDigestForPublicImage()
-        => await AssertResolvesAsync(Ghcr(), "home-assistant/home-assistant", "stable");
+        => await AssertResolvesAsync(Ghcr(), "ghcr.io", "home-assistant/home-assistant", "stable");
 
     [IntegrationFact]
     public async Task GenericOci_ResolvesDigestForMcr()
-        => await AssertResolvesAsync(Generic(), "mcr.microsoft.com/dotnet/aspnet", "10.0-noble");
+        => await AssertResolvesAsync(Generic(), "mcr.microsoft.com", "dotnet/aspnet", "10.0-noble");
+
+    [IntegrationFact]
+    public async Task GenericOci_ResolvesDigestForLscr()
+        => await AssertResolvesAsync(Generic(), "lscr.io", "linuxserver/radarr", "latest");
 }

--- a/lighthouse-back/lighthouse-back/src/Services/ImageDigestService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/ImageDigestService.cs
@@ -272,13 +272,13 @@ public class ImageDigestService : IImageDigestService
             {
                 // GET: also returns the creation date (counts against the pull-rate limit).
                 (digest, createdAt) = await client.GetManifestDigestAndCreatedAtAsync(
-                    imageRef.Repository, imageRef.Tag, architecture, ct);
+                    imageRef.Registry, imageRef.Repository, imageRef.Tag, architecture, ct);
             }
             else
             {
                 // HEAD: digest only, not counted against the pull-rate limit.
                 digest = await client.GetManifestDigestAsync(
-                    imageRef.Repository, imageRef.Tag, architecture, ct);
+                    imageRef.Registry, imageRef.Repository, imageRef.Tag, architecture, ct);
             }
 
             return new ImageDigestInfo(

--- a/lighthouse-back/lighthouse-back/src/Services/Registry/DockerHubRegistryClient.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/Registry/DockerHubRegistryClient.cs
@@ -38,21 +38,23 @@ public class DockerHubRegistryClient : RegistryClientBase
     }
 
     public override async Task<string?> GetManifestDigestAsync(
-        string image,
+        string registry,
+        string repository,
         string tag,
         string architecture,
         CancellationToken cancellationToken = default)
     {
+        // The registry parameter is ignored: this client always talks to registry-1.docker.io.
         try
         {
-            string? token = await GetAuthTokenAsync(image, cancellationToken);
+            string? token = await GetAuthTokenAsync(repository, cancellationToken);
             if (token == null)
             {
-                Logger.LogWarning("Failed to get auth token for image {Image}", image);
+                Logger.LogWarning("Failed to get auth token for repository {Repository}", repository);
                 return null;
             }
 
-            return await FetchManifestDigestViaHeadAsync(image, tag, architecture, token, cancellationToken);
+            return await FetchManifestDigestViaHeadAsync(repository, tag, architecture, token, cancellationToken);
         }
         catch (RegistryRateLimitException)
         {
@@ -60,7 +62,7 @@ public class DockerHubRegistryClient : RegistryClientBase
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Error getting manifest digest (HEAD) for {Image}:{Tag}", image, tag);
+            Logger.LogError(ex, "Error getting manifest digest (HEAD) for {Repository}:{Tag}", repository, tag);
             return null;
         }
     }
@@ -121,21 +123,23 @@ public class DockerHubRegistryClient : RegistryClientBase
     }
 
     public override async Task<(string? Digest, DateTime? CreatedAt)> GetManifestDigestAndCreatedAtAsync(
-        string image,
+        string registry,
+        string repository,
         string tag,
         string architecture,
         CancellationToken cancellationToken = default)
     {
+        // The registry parameter is ignored: this client always talks to registry-1.docker.io.
         try
         {
-            string? token = await GetAuthTokenAsync(image, cancellationToken);
+            string? token = await GetAuthTokenAsync(repository, cancellationToken);
             if (token == null)
             {
-                Logger.LogWarning("Failed to get auth token for image {Image}", image);
+                Logger.LogWarning("Failed to get auth token for repository {Repository}", repository);
                 return (null, null);
             }
 
-            var (digest, configDigest) = await FetchManifestDigestAndConfigAsync(image, tag, architecture, token, cancellationToken);
+            var (digest, configDigest) = await FetchManifestDigestAndConfigAsync(repository, tag, architecture, token, cancellationToken);
 
             if (digest == null)
             {
@@ -145,7 +149,7 @@ public class DockerHubRegistryClient : RegistryClientBase
             DateTime? createdAt = null;
             if (configDigest != null)
             {
-                createdAt = await FetchConfigCreatedAtAsync(RegistryUrl, image, configDigest, token, cancellationToken);
+                createdAt = await FetchConfigCreatedAtAsync(RegistryUrl, repository, configDigest, token, cancellationToken);
             }
 
             return (digest, createdAt);
@@ -156,7 +160,7 @@ public class DockerHubRegistryClient : RegistryClientBase
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Error getting manifest digest for {Image}:{Tag}", image, tag);
+            Logger.LogError(ex, "Error getting manifest digest for {Repository}:{Tag}", repository, tag);
             return (null, null);
         }
     }

--- a/lighthouse-back/lighthouse-back/src/Services/Registry/GenericOciRegistryClient.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/Registry/GenericOciRegistryClient.cs
@@ -8,7 +8,7 @@ namespace Lighthouse.Services.Registry;
 
 /// <summary>
 /// Generic registry client for OCI-compliant registries.
-/// Used as a fallback for registries without specific implementations.
+/// Used as a fallback for registries without specific implementations (e.g., lscr.io, mcr.microsoft.com).
 /// </summary>
 public class GenericOciRegistryClient : RegistryClientBase
 {
@@ -27,15 +27,14 @@ public class GenericOciRegistryClient : RegistryClientBase
     }
 
     public override async Task<string?> GetManifestDigestAsync(
-        string image,
+        string registry,
+        string repository,
         string tag,
         string architecture,
         CancellationToken cancellationToken = default)
     {
         try
         {
-            string registry = ExtractRegistry(image);
-            string repository = ExtractRepository(image);
             string registryUrl = $"https://{registry}/v2";
 
             // Try HEAD anonymously first (HEAD is not counted against pull-rate limits).
@@ -46,7 +45,7 @@ public class GenericOciRegistryClient : RegistryClientBase
                 return digest;
             }
 
-            string? token = await GetTokenViaWwwAuthenticateAsync(registryUrl, repository, cancellationToken);
+            string? token = await GetTokenViaWwwAuthenticateAsync(registryUrl, repository, tag, cancellationToken);
             if (token != null)
             {
                 return await TryFetchDigestViaHeadAsync(
@@ -61,7 +60,7 @@ public class GenericOciRegistryClient : RegistryClientBase
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Error getting manifest digest (HEAD) for {Image}:{Tag}", image, tag);
+            Logger.LogError(ex, "Error getting manifest digest (HEAD) for {Registry}/{Repository}:{Tag}", registry, repository, tag);
             return null;
         }
     }
@@ -78,7 +77,6 @@ public class GenericOciRegistryClient : RegistryClientBase
         string? token,
         CancellationToken cancellationToken)
     {
-        repository = StripTag(repository);
         string url = $"{registryUrl}/{repository}/manifests/{tag}";
 
         using HttpRequestMessage request = new(HttpMethod.Head, url);
@@ -129,15 +127,14 @@ public class GenericOciRegistryClient : RegistryClientBase
     }
 
     public override async Task<(string? Digest, DateTime? CreatedAt)> GetManifestDigestAndCreatedAtAsync(
-        string image,
+        string registry,
+        string repository,
         string tag,
         string architecture,
         CancellationToken cancellationToken = default)
     {
         try
         {
-            string registry = ExtractRegistry(image);
-            string repository = ExtractRepository(image);
             string registryUrl = $"https://{registry}/v2";
 
             // First, try without authentication
@@ -153,7 +150,7 @@ public class GenericOciRegistryClient : RegistryClientBase
             Logger.LogDebug("Anonymous access failed for {Registry}/{Repository}, attempting token auth", registry, repository);
 
             string? token = await GetTokenViaWwwAuthenticateAsync(
-                registryUrl, repository, cancellationToken);
+                registryUrl, repository, tag, cancellationToken);
 
             if (token != null)
             {
@@ -169,66 +166,23 @@ public class GenericOciRegistryClient : RegistryClientBase
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Error getting manifest digest for {Image}:{Tag}", image, tag);
+            Logger.LogError(ex, "Error getting manifest digest for {Registry}/{Repository}:{Tag}", registry, repository, tag);
             return (null, null);
         }
-    }
-
-    private string ExtractRegistry(string image)
-    {
-        int slashIndex = image.IndexOf('/');
-        if (slashIndex > 0)
-        {
-            string firstPart = image.Substring(0, slashIndex);
-            if (firstPart.Contains('.') || firstPart.Contains(':') || firstPart == "localhost")
-            {
-                return firstPart;
-            }
-        }
-        return "docker.io";
-    }
-
-    private string ExtractRepository(string image)
-    {
-        int slashIndex = image.IndexOf('/');
-        if (slashIndex > 0)
-        {
-            string firstPart = image.Substring(0, slashIndex);
-            if (firstPart.Contains('.') || firstPart.Contains(':') || firstPart == "localhost")
-            {
-                return image.Substring(slashIndex + 1);
-            }
-        }
-
-        // For Docker Hub official images
-        if (!image.Contains('/'))
-        {
-            return "library/" + image;
-        }
-
-        return image;
-    }
-
-    /// <summary>Removes a trailing <c>:tag</c> from a repository segment, if present.</summary>
-    private static string StripTag(string repository)
-    {
-        int colonIndex = repository.LastIndexOf(':');
-        if (colonIndex > 0 && !repository.Substring(colonIndex).Contains('/'))
-        {
-            return repository.Substring(0, colonIndex);
-        }
-        return repository;
     }
 
     private async Task<string?> GetTokenViaWwwAuthenticateAsync(
         string registryUrl,
         string repository,
+        string tag,
         CancellationToken cancellationToken)
     {
         try
         {
-            // Make a request to trigger 401 and get WWW-Authenticate header
-            string url = $"{registryUrl}/{repository}/manifests/latest";
+            // Make a request to trigger 401 and get WWW-Authenticate header. Use the requested tag:
+            // some registries validate the tag before issuing the challenge, so probing a hardcoded
+            // "latest" would fail for repositories that don't have that tag.
+            string url = $"{registryUrl}/{repository}/manifests/{tag}";
 
             using HttpRequestMessage request = new(HttpMethod.Get, url);
             HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken);
@@ -316,7 +270,6 @@ public class GenericOciRegistryClient : RegistryClientBase
         string? token,
         CancellationToken cancellationToken)
     {
-        repository = StripTag(repository);
         string url = $"{registryUrl}/{repository}/manifests/{tag}";
 
         using HttpRequestMessage request = new(HttpMethod.Get, url);

--- a/lighthouse-back/lighthouse-back/src/Services/Registry/GhcrRegistryClient.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/Registry/GhcrRegistryClient.cs
@@ -31,15 +31,17 @@ public class GhcrRegistryClient : RegistryClientBase
     }
 
     public override async Task<string?> GetManifestDigestAsync(
-        string image,
+        string registry,
+        string repository,
         string tag,
         string architecture,
         CancellationToken cancellationToken = default)
     {
+        // The registry parameter is ignored: this client always talks to ghcr.io.
         try
         {
             string? token = GetAuthToken();
-            return await FetchManifestDigestViaHeadAsync(image, tag, architecture, token, cancellationToken);
+            return await FetchManifestDigestViaHeadAsync(repository, tag, architecture, token, cancellationToken);
         }
         catch (RegistryRateLimitException)
         {
@@ -47,7 +49,7 @@ public class GhcrRegistryClient : RegistryClientBase
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Error getting manifest digest (HEAD) for ghcr.io/{Image}:{Tag}", image, tag);
+            Logger.LogError(ex, "Error getting manifest digest (HEAD) for ghcr.io/{Repository}:{Tag}", repository, tag);
             return null;
         }
     }
@@ -91,7 +93,7 @@ public class GhcrRegistryClient : RegistryClientBase
 
         if (response.StatusCode is HttpStatusCode.MethodNotAllowed or HttpStatusCode.NotImplemented)
         {
-            var (fallbackDigest, _) = await GetManifestDigestAndCreatedAtAsync(repository, tag, architecture, cancellationToken);
+            var (fallbackDigest, _) = await GetManifestDigestAndCreatedAtAsync("ghcr.io", repository, tag, architecture, cancellationToken);
             return fallbackDigest;
         }
 
@@ -107,7 +109,7 @@ public class GhcrRegistryClient : RegistryClientBase
             return digestValues.FirstOrDefault();
         }
 
-        var (digest, _) = await GetManifestDigestAndCreatedAtAsync(repository, tag, architecture, cancellationToken);
+        var (digest, _) = await GetManifestDigestAndCreatedAtAsync("ghcr.io", repository, tag, architecture, cancellationToken);
         return digest;
     }
 
@@ -133,7 +135,7 @@ public class GhcrRegistryClient : RegistryClientBase
 
         if (response.StatusCode is HttpStatusCode.MethodNotAllowed or HttpStatusCode.NotImplemented)
         {
-            var (fallbackDigest, _) = await GetManifestDigestAndCreatedAtAsync(repository, tag, architecture, cancellationToken);
+            var (fallbackDigest, _) = await GetManifestDigestAndCreatedAtAsync("ghcr.io", repository, tag, architecture, cancellationToken);
             return fallbackDigest;
         }
 
@@ -149,22 +151,24 @@ public class GhcrRegistryClient : RegistryClientBase
             return digestValues.FirstOrDefault();
         }
 
-        var (digest, _) = await GetManifestDigestAndCreatedAtAsync(repository, tag, architecture, cancellationToken);
+        var (digest, _) = await GetManifestDigestAndCreatedAtAsync("ghcr.io", repository, tag, architecture, cancellationToken);
         return digest;
     }
 
     public override async Task<(string? Digest, DateTime? CreatedAt)> GetManifestDigestAndCreatedAtAsync(
-        string image,
+        string registry,
+        string repository,
         string tag,
         string architecture,
         CancellationToken cancellationToken = default)
     {
+        // The registry parameter is ignored: this client always talks to ghcr.io.
         try
         {
             // Get token for GHCR (anonymous or authenticated)
             string? token = GetAuthToken();
 
-            return await FetchManifestDigestAndCreatedAtAsync(image, tag, architecture, token, cancellationToken);
+            return await FetchManifestDigestAndCreatedAtAsync(repository, tag, architecture, token, cancellationToken);
         }
         catch (RegistryRateLimitException)
         {
@@ -172,7 +176,7 @@ public class GhcrRegistryClient : RegistryClientBase
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Error getting manifest digest for ghcr.io/{Image}:{Tag}", image, tag);
+            Logger.LogError(ex, "Error getting manifest digest for ghcr.io/{Repository}:{Tag}", repository, tag);
             return (null, null);
         }
     }

--- a/lighthouse-back/lighthouse-back/src/Services/Registry/IRegistryClient.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/Registry/IRegistryClient.cs
@@ -8,13 +8,15 @@ public interface IRegistryClient
     /// <summary>
     /// Gets the manifest digest for an image from the registry.
     /// </summary>
-    /// <param name="image">The full image reference (e.g., "nginx:latest", "ghcr.io/owner/repo:tag")</param>
+    /// <param name="registry">The registry hostname (e.g., "docker.io", "lscr.io", "localhost:5000")</param>
+    /// <param name="repository">The repository within the registry (e.g., "library/nginx", "linuxserver/radarr")</param>
     /// <param name="tag">The image tag</param>
     /// <param name="architecture">The target architecture (e.g., "amd64", "arm64")</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The manifest digest (sha256:...) or null if not found</returns>
     Task<string?> GetManifestDigestAsync(
-        string image,
+        string registry,
+        string repository,
         string tag,
         string architecture,
         CancellationToken cancellationToken = default);
@@ -22,13 +24,15 @@ public interface IRegistryClient
     /// <summary>
     /// Gets the manifest digest and creation date for an image from the registry.
     /// </summary>
-    /// <param name="image">The full image reference (e.g., "nginx:latest", "ghcr.io/owner/repo:tag")</param>
+    /// <param name="registry">The registry hostname (e.g., "docker.io", "lscr.io", "localhost:5000")</param>
+    /// <param name="repository">The repository within the registry (e.g., "library/nginx", "linuxserver/radarr")</param>
     /// <param name="tag">The image tag</param>
     /// <param name="architecture">The target architecture (e.g., "amd64", "arm64")</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Tuple of (digest, createdAt) where digest is sha256:... or null if not found</returns>
     Task<(string? Digest, DateTime? CreatedAt)> GetManifestDigestAndCreatedAtAsync(
-        string image,
+        string registry,
+        string repository,
         string tag,
         string architecture,
         CancellationToken cancellationToken = default);

--- a/lighthouse-back/lighthouse-back/src/Services/Registry/RegistryClientBase.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/Registry/RegistryClientBase.cs
@@ -24,10 +24,10 @@ public abstract class RegistryClientBase : IRegistryClient
     public abstract bool CanHandle(string registry);
 
     public abstract Task<string?> GetManifestDigestAsync(
-        string image, string tag, string architecture, CancellationToken cancellationToken = default);
+        string registry, string repository, string tag, string architecture, CancellationToken cancellationToken = default);
 
     public abstract Task<(string? Digest, DateTime? CreatedAt)> GetManifestDigestAndCreatedAtAsync(
-        string image, string tag, string architecture, CancellationToken cancellationToken = default);
+        string registry, string repository, string tag, string architecture, CancellationToken cancellationToken = default);
 
     /// <summary>Adds the manifest-list and single-manifest Accept headers used for digest lookups.</summary>
     protected static void AddManifestAcceptHeaders(HttpRequestMessage request)


### PR DESCRIPTION
## Problem

Images hosted on registries without a dedicated client — notably **lscr.io** (LinuxServer.io) — always failed the update check and were never flagged as updatable.

Root cause: `ImageDigestService` passed only the parsed repository (e.g. `linuxserver/radarr`) to `IRegistryClient`, and `GenericOciRegistryClient` re-derived the registry from that string. With no registry hostname left in it, the derivation fell back to `docker.io`, so the manifest request hit the wrong host and the remote digest was always `null` (`"Failed to fetch remote digest"`).

A second latent bug: the generic client's `WWW-Authenticate` token probe hardcoded `manifests/latest`, which breaks on registries that validate the tag before issuing the auth challenge when the repository has no `latest` tag.

## Fix

- `IRegistryClient.GetManifestDigestAsync` / `GetManifestDigestAndCreatedAtAsync` now take `registry` and `repository` as separate parameters.
- `ImageDigestService` passes `imageRef.Registry` from the parsed image reference.
- `GenericOciRegistryClient` uses the provided registry host directly; `ExtractRegistry` / `ExtractRepository` / `StripTag` removed (dead code once the registry is supplied).
- The token probe uses the requested tag instead of hardcoded `latest`.
- `DockerHubRegistryClient` and `GhcrRegistryClient` ignore the new parameter (hardcoded endpoints), unchanged behavior.

## Tests

- `GetManifestDigestAsync_TargetsProvidedRegistryHost`: asserts all requests go to `https://lscr.io/v2/linuxserver/radarr/...` (regression for the main bug).
- `GetManifestDigestAsync_TokenProbeUsesRequestedTag`: asserts the 401 probe never touches `manifests/latest` (regression for the second bug).
- New integration test `GenericOci_ResolvesDigestForLscr` against the real lscr.io registry.
- Full suite: 468 unit tests pass; 4/4 registry integration tests pass (`RUN_REGISTRY_INTEGRATION=1`), including lscr.io resolving HEAD and GET digests identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)