### PR TITLE
feat(update): preserve container run state after image update

### DIFF
--- a/lighthouse-back/lighthouse-back.Tests/Services/ComposeUpdateServiceTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Services/ComposeUpdateServiceTests.cs
@@ -21,6 +21,7 @@ public class ComposeUpdateServiceTests
         _checker.Object,
         cacheService: null!,
         dockerExecutor: null!,
+        dockerOps: null!,
         envFileResolver: null!,
         progressParser: null!,
         operationServiceDb: null!,

--- a/lighthouse-back/lighthouse-back.Tests/Utils/ContainerRunStateHelperTests.cs
+++ b/lighthouse-back/lighthouse-back.Tests/Utils/ContainerRunStateHelperTests.cs
@@ -1,0 +1,105 @@
+using Docker.DotNet.Models;
+using FluentAssertions;
+using Lighthouse.Utils;
+
+namespace Lighthouse.Tests.Utils;
+
+public class ContainerRunStateHelperTests
+{
+    [Theory]
+    [InlineData("running", true)]
+    [InlineData("paused", true)]
+    [InlineData("restarting", true)]
+    [InlineData("exited", false)]
+    [InlineData("created", false)]
+    [InlineData("dead", false)]
+    [InlineData("removing", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsRunningState_ClassifiesDockerStates(string? state, bool expected)
+    {
+        ContainerRunStateHelper.IsRunningState(state).Should().Be(expected);
+    }
+
+    [Fact]
+    public void GetComposeServiceRunStates_MapsServicesToRunState()
+    {
+        var containers = new List<ContainerListResponse>
+        {
+            MakeContainer("proj", "web", "running"),
+            MakeContainer("proj", "db", "exited"),
+            MakeContainer("proj", "worker", "created")
+        };
+
+        Dictionary<string, bool> states = ContainerRunStateHelper.GetComposeServiceRunStates(containers, "proj");
+
+        states.Should().HaveCount(3);
+        states["web"].Should().BeTrue();
+        states["db"].Should().BeFalse();
+        states["worker"].Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetComposeServiceRunStates_IgnoresOtherProjectsAndUnlabeledContainers()
+    {
+        var containers = new List<ContainerListResponse>
+        {
+            MakeContainer("proj", "web", "running"),
+            MakeContainer("other-proj", "web", "exited"),
+            new() { State = "running", Labels = null },
+            new() { State = "running", Labels = new Dictionary<string, string>() }
+        };
+
+        Dictionary<string, bool> states = ContainerRunStateHelper.GetComposeServiceRunStates(containers, "proj");
+
+        states.Should().HaveCount(1);
+        states["web"].Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetComposeServiceRunStates_ServiceWithReplicas_IsRunningIfAnyReplicaRuns()
+    {
+        var containers = new List<ContainerListResponse>
+        {
+            MakeContainer("proj", "web", "exited"),
+            MakeContainer("proj", "web", "running"),
+            MakeContainer("proj", "db", "exited"),
+            MakeContainer("proj", "db", "exited")
+        };
+
+        Dictionary<string, bool> states = ContainerRunStateHelper.GetComposeServiceRunStates(containers, "proj");
+
+        states["web"].Should().BeTrue();
+        states["db"].Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetComposeServiceRunStates_MatchesProjectNameCaseInsensitively()
+    {
+        var containers = new List<ContainerListResponse>
+        {
+            MakeContainer("MyProj", "web", "running")
+        };
+
+        Dictionary<string, bool> states = ContainerRunStateHelper.GetComposeServiceRunStates(containers, "myproj");
+
+        states.Should().ContainKey("web");
+    }
+
+    [Fact]
+    public void GetComposeServiceRunStates_NoContainers_ReturnsEmpty()
+    {
+        ContainerRunStateHelper.GetComposeServiceRunStates(new List<ContainerListResponse>(), "proj")
+            .Should().BeEmpty();
+    }
+
+    private static ContainerListResponse MakeContainer(string project, string service, string state) => new()
+    {
+        State = state,
+        Labels = new Dictionary<string, string>
+        {
+            ["com.docker.compose.project"] = project,
+            ["com.docker.compose.service"] = service
+        }
+    };
+}

--- a/lighthouse-back/lighthouse-back/src/Services/ComposeUpdateService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/ComposeUpdateService.cs
@@ -1,7 +1,9 @@
 ﻿using System.Text;
+using Docker.DotNet.Models;
 using Lighthouse.Configuration;
 using Lighthouse.DTOs;
 using Lighthouse.Services.Registry;
+using Lighthouse.Utils;
 using Microsoft.Extensions.Options;
 using YamlDotNet.Serialization;
 
@@ -65,6 +67,7 @@ public class ComposeUpdateService : IComposeUpdateService
     private readonly IComposeUpdateChecker _checker;
     private readonly IImageUpdateCacheService _cacheService;
     private readonly DockerCommandExecutorService _dockerExecutor;
+    private readonly IDockerImageOperations _dockerOps;
     private readonly IComposeEnvFileResolver _envFileResolver;
     private readonly DockerPullProgressParser _progressParser;
     private readonly IOperationService _operationService;
@@ -76,6 +79,7 @@ public class ComposeUpdateService : IComposeUpdateService
         IComposeUpdateChecker checker,
         IImageUpdateCacheService cacheService,
         DockerCommandExecutorService dockerExecutor,
+        IDockerImageOperations dockerOps,
         IComposeEnvFileResolver envFileResolver,
         DockerPullProgressParser progressParser,
         IOperationService operationServiceDb,
@@ -86,6 +90,7 @@ public class ComposeUpdateService : IComposeUpdateService
         _checker = checker;
         _cacheService = cacheService;
         _dockerExecutor = dockerExecutor;
+        _dockerOps = dockerOps;
         _envFileResolver = envFileResolver;
         _progressParser = progressParser;
         _operationService = operationServiceDb;
@@ -402,11 +407,15 @@ public class ComposeUpdateService : IComposeUpdateService
             }
             await SendProgressUpdateAsync(operationId, projectName, "recreate", serviceProgress, "Recreating containers...", restartAfterUpdate);
 
-            // Recreate containers with new images
-            string recreateArgs = restartFullProject
-                ? $"compose {envFileArgs}-f \"{composeFilePath}\" up -d --force-recreate"
-                : $"compose {envFileArgs}-f \"{composeFilePath}\" up -d --force-recreate {servicesArg}";
-            _logger.LogDebug("Recreating containers - RestartFullProject: {RestartFullProject}, Command args: {Args}", restartFullProject, recreateArgs);
+            // Determine which services were running before the update so the recreate phase
+            // can restore the previous run state: running services are recreated and started,
+            // stopped services are recreated with the new image but left stopped.
+            (List<string> servicesToStart, List<string> servicesToLeaveStopped) =
+                await SplitServicesByRunStateAsync(projectName, servicesToUpdate, restartFullProject, ct);
+
+            _logger.LogDebug(
+                "Recreating containers for {ProjectName} - Start: [{Start}], LeaveStopped: [{LeaveStopped}], RestartFullProject: {RestartFullProject}",
+                projectName, string.Join(", ", servicesToStart), string.Join(", ", servicesToLeaveStopped), restartFullProject);
 
             var recreateLogs = new StringBuilder();
 
@@ -427,13 +436,36 @@ public class ComposeUpdateService : IComposeUpdateService
                 }
             }
 
-            (int upExitCode, string upOutput, string upError) = await _dockerExecutor.ExecuteWithStreamingAsync(
-                "docker",
-                recreateArgs,
-                OnRecreateOutput,
-                OnRecreateOutput,
-                ct,
-                workingDirectory: composeDirectory);
+            List<string> recreateCommands = new();
+            if (servicesToStart.Count > 0)
+            {
+                recreateCommands.Add($"compose {envFileArgs}-f \"{composeFilePath}\" up -d --force-recreate {string.Join(" ", servicesToStart)}");
+            }
+            if (servicesToLeaveStopped.Count > 0)
+            {
+                // `compose create --force-recreate` swaps in the new image without starting
+                // the container, preserving the pre-update stopped state.
+                recreateCommands.Add($"compose {envFileArgs}-f \"{composeFilePath}\" create --force-recreate {string.Join(" ", servicesToLeaveStopped)}");
+            }
+
+            int upExitCode = 0;
+            string upError = string.Empty;
+
+            foreach (string recreateArgs in recreateCommands)
+            {
+                _logger.LogDebug("Recreate command args: {Args}", recreateArgs);
+
+                (upExitCode, _, upError) = await _dockerExecutor.ExecuteWithStreamingAsync(
+                    "docker",
+                    recreateArgs,
+                    OnRecreateOutput,
+                    OnRecreateOutput,
+                    ct,
+                    workingDirectory: composeDirectory);
+
+                if (upExitCode != 0)
+                    break;
+            }
 
             if (upExitCode != 0)
             {
@@ -478,6 +510,10 @@ public class ComposeUpdateService : IComposeUpdateService
             filteredLogs.AppendLine($"Pull completed for {servicesToUpdate.Count} services");
             filteredLogs.AppendLine("Recreating containers...");
             filteredLogs.Append(recreateLogs);
+            if (servicesToLeaveStopped.Count > 0)
+            {
+                filteredLogs.AppendLine($"Left stopped (previous state preserved): {string.Join(", ", servicesToLeaveStopped)}");
+            }
             filteredLogs.AppendLine("Update completed successfully");
             await _operationService.AppendLogsAsync(operationId, filteredLogs.ToString());
             await _operationService.UpdateOperationStatusAsync(operationId, Models.OperationStatus.Completed, progress: 100);
@@ -518,6 +554,52 @@ public class ComposeUpdateService : IComposeUpdateService
                 OperationId: operationId
             );
         }
+    }
+
+    /// <summary>
+    /// Splits the services to recreate into those that should be started (they had at least
+    /// one running container before the update) and those that should be recreated but left
+    /// stopped, so the update preserves the pre-update run state. With
+    /// <paramref name="restartFullProject"/> the split covers every service of the project
+    /// that has a container, not just the updated ones. If container states cannot be read,
+    /// all services are started (previous behavior).
+    /// </summary>
+    private async Task<(List<string> ToStart, List<string> ToLeaveStopped)> SplitServicesByRunStateAsync(
+        string projectName,
+        List<string> servicesToUpdate,
+        bool restartFullProject,
+        CancellationToken ct)
+    {
+        Dictionary<string, bool> runStates;
+        try
+        {
+            IList<ContainerListResponse> containers = await _dockerOps.ListContainersRawAsync(ct);
+            runStates = ContainerRunStateHelper.GetComposeServiceRunStates(containers, projectName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to read container states for {ProjectName}; recreated containers will all be started",
+                projectName);
+            return (servicesToUpdate.ToList(), new List<string>());
+        }
+
+        IEnumerable<string> targetServices = restartFullProject
+            ? runStates.Keys.Union(servicesToUpdate, StringComparer.Ordinal)
+            : servicesToUpdate;
+
+        List<string> toStart = new();
+        List<string> toLeaveStopped = new();
+        foreach (string service in targetServices)
+        {
+            // A service with no pre-existing container was not running, so it stays stopped.
+            if (runStates.TryGetValue(service, out bool isRunning) && isRunning)
+                toStart.Add(service);
+            else
+                toLeaveStopped.Add(service);
+        }
+
+        return (toStart, toLeaveStopped);
     }
 
     private async Task SendProgressUpdateAsync(

--- a/lighthouse-back/lighthouse-back/src/Services/ContainerUpdateService.cs
+++ b/lighthouse-back/lighthouse-back/src/Services/ContainerUpdateService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using Lighthouse.DTOs;
+using Lighthouse.Utils;
 
 namespace Lighthouse.Services;
 
@@ -219,9 +220,15 @@ public class ContainerUpdateService : IContainerUpdateService
         bool operationCreated = false;
         var filteredLogs = new StringBuilder();
 
+        // Capture the pre-update run state so the recreated container can be left stopped
+        // when the old one was not running.
+        bool wasRunning = ContainerRunStateHelper.IsRunningState(container.State);
+
         try
         {
-            _logger.LogInformation("Updating standalone container {ContainerName} ({Image}), restartAfterUpdate: {RestartAfterUpdate}", containerName, container.Image, restartAfterUpdate);
+            _logger.LogInformation(
+                "Updating standalone container {ContainerName} ({Image}), restartAfterUpdate: {RestartAfterUpdate}, wasRunning: {WasRunning}",
+                containerName, container.Image, restartAfterUpdate, wasRunning);
 
             // Create operation for action log tracking
             await _operationService.CreateOperationAsync(
@@ -372,7 +379,9 @@ public class ContainerUpdateService : IContainerUpdateService
                 return new UpdateTriggerResponse(false, $"Failed to remove container: {rmError}", operationId);
             }
 
-            // 3. Recreate container with same config using docker run
+            // 3. Recreate container with same config. If the old container was running,
+            // start the new one (docker run); otherwise recreate it without starting
+            // (docker create) to preserve the pre-update stopped state.
             filteredLogs.AppendLine("Creating new container...");
             serviceProgress[containerName] = serviceProgress[containerName] with
             {
@@ -381,12 +390,13 @@ public class ContainerUpdateService : IContainerUpdateService
             };
             await SendStandaloneProgressAsync(operationId, containerName, container.Id, "recreate", serviceProgress, "Creating new container...", restartAfterUpdate);
 
-            string runArgs = BuildDockerRunArgs(container);
-            _logger.LogDebug("Recreating container with args: docker run {Args}", runArgs);
+            string containerArgs = BuildDockerRunArgs(container);
+            string recreateCommand = wasRunning ? $"run -d {containerArgs}" : $"create {containerArgs}";
+            _logger.LogDebug("Recreating container with args: docker {Args}", recreateCommand);
 
             (int runExitCode, string runOutput, string runError) = await _dockerExecutor.ExecuteAsync(
                 "docker",
-                $"run {runArgs}",
+                recreateCommand,
                 ct);
 
             if (runExitCode != 0)
@@ -407,22 +417,32 @@ public class ContainerUpdateService : IContainerUpdateService
             }
 
             // Mark as completed
+            string completionMessage = wasRunning
+                ? "Update completed"
+                : "Update completed (container left stopped)";
             serviceProgress[containerName] = serviceProgress[containerName] with
             {
                 Status = "completed",
                 ProgressPercent = 100,
-                Message = "Update completed"
+                Message = completionMessage
             };
-            await SendStandaloneProgressAsync(operationId, containerName, container.Id, "recreate", serviceProgress, "Update completed", restartAfterUpdate);
+            await SendStandaloneProgressAsync(operationId, containerName, container.Id, "recreate", serviceProgress, completionMessage, restartAfterUpdate);
 
-            filteredLogs.AppendLine("Update completed successfully");
+            filteredLogs.AppendLine(wasRunning
+                ? "Update completed successfully"
+                : "Update completed successfully (container left stopped, previous state preserved)");
             await _operationService.AppendLogsAsync(operationId, filteredLogs.ToString());
             await _operationService.UpdateOperationStatusAsync(operationId, Models.OperationStatus.Completed, progress: 100);
 
-            _logger.LogInformation("Updated standalone container {ContainerName} ({Image}) by user {UserId}",
-                containerName, container.Image, userId);
+            _logger.LogInformation("Updated standalone container {ContainerName} ({Image}) by user {UserId}, wasRunning: {WasRunning}",
+                containerName, container.Image, userId, wasRunning);
 
-            return new UpdateTriggerResponse(true, $"Successfully updated container {containerName}", operationId);
+            return new UpdateTriggerResponse(
+                true,
+                wasRunning
+                    ? $"Successfully updated container {containerName}"
+                    : $"Successfully updated container {containerName} (container left stopped)",
+                operationId);
         }
         catch (Exception ex)
         {
@@ -492,11 +512,12 @@ public class ContainerUpdateService : IContainerUpdateService
     }
 
     /// <summary>
-    /// Builds docker run arguments to recreate a container with the same configuration.
+    /// Builds the shared arguments (name, env, ports, mounts, ...) used to recreate a
+    /// container with the same configuration via `docker run -d` or `docker create`.
     /// </summary>
     private static string BuildDockerRunArgs(ContainerDetailsDto container)
     {
-        List<string> args = new() { "-d" };
+        List<string> args = new();
 
         // Container name
         string containerName = container.Name.TrimStart('/');

--- a/lighthouse-back/lighthouse-back/src/Utils/ContainerRunStateHelper.cs
+++ b/lighthouse-back/lighthouse-back/src/Utils/ContainerRunStateHelper.cs
@@ -1,0 +1,55 @@
+using Docker.DotNet.Models;
+
+namespace Lighthouse.Utils;
+
+/// <summary>
+/// Helpers to reason about whether containers were running before an image update,
+/// so the update flow can restore the previous run state instead of always starting
+/// the recreated containers.
+/// </summary>
+public static class ContainerRunStateHelper
+{
+    private const string ComposeProjectLabel = "com.docker.compose.project";
+    private const string ComposeServiceLabel = "com.docker.compose.service";
+
+    /// <summary>
+    /// Returns true when the Docker container state counts as "running" for update purposes.
+    /// Paused and restarting containers are treated as running: a recreate cannot restore
+    /// those exact states, so starting the new container is the closest match.
+    /// </summary>
+    public static bool IsRunningState(string? state) =>
+        state is "running" or "paused" or "restarting";
+
+    /// <summary>
+    /// Maps each compose service of <paramref name="projectName"/> to whether at least one
+    /// of its containers is currently running. Services with no containers are absent from
+    /// the result.
+    /// </summary>
+    public static Dictionary<string, bool> GetComposeServiceRunStates(
+        IEnumerable<ContainerListResponse> containers,
+        string projectName)
+    {
+        Dictionary<string, bool> runStates = new(StringComparer.Ordinal);
+
+        foreach (ContainerListResponse container in containers)
+        {
+            if (container.Labels == null)
+                continue;
+
+            if (!container.Labels.TryGetValue(ComposeProjectLabel, out string? project)
+                || !string.Equals(project, projectName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (!container.Labels.TryGetValue(ComposeServiceLabel, out string? service)
+                || string.IsNullOrEmpty(service))
+                continue;
+
+            bool isRunning = IsRunningState(container.State);
+            runStates[service] = runStates.TryGetValue(service, out bool existing)
+                ? existing || isRunning
+                : isRunning;
+        }
+
+        return runStates;
+    }
+}

--- a/lighthouse-front/src/lib/i18n/en.ts
+++ b/lighthouse-front/src/lib/i18n/en.ts
@@ -657,7 +657,7 @@ export default {
     updateSelected: 'Update Selected',
     updateSuccess: 'Successfully updated {count} services',
     restartAfterUpdate: 'Restart after update',
-    restartAfterUpdateHint: 'Recreate containers with the new images. Uncheck to only pull images without restarting.',
+    restartAfterUpdateHint: 'Recreate containers with the new images. Containers that were stopped stay stopped. Uncheck to only pull images without restarting.',
     restartFullProject: 'Restart entire project',
     restartFullProjectHint: 'Restarts all services in the project, not just the updated ones',
     // Bulk update keys

--- a/lighthouse-front/src/lib/i18n/fr.ts
+++ b/lighthouse-front/src/lib/i18n/fr.ts
@@ -657,7 +657,7 @@ const fr = {
     updateSelected: 'Mettre à jour la sélection',
     updateSuccess: '{count} services mis à jour avec succès',
     restartAfterUpdate: 'Redémarrer après mise à jour',
-    restartAfterUpdateHint: 'Recrée les conteneurs avec les nouvelles images. Décochez pour uniquement télécharger les images sans redémarrer.',
+    restartAfterUpdateHint: 'Recrée les conteneurs avec les nouvelles images. Les conteneurs arrêtés restent arrêtés. Décochez pour uniquement télécharger les images sans redémarrer.',
     restartFullProject: 'Redémarrer le projet en entier',
     restartFullProjectHint: 'Redémarre tous les services du projet, pas uniquement ceux mis à jour',
     // Bulk update keys


### PR DESCRIPTION
## Problem

After updating an image, the associated container was always started, even if it was stopped before the update. Both update paths unconditionally started the recreated containers:

- **Standalone containers** (`ContainerUpdateService`): pull → stop → rm → `docker run -d` (always started).
- **Compose projects** (`ComposeUpdateService`): `docker compose up -d --force-recreate` (starts every targeted service, worse with *restart full project*).

## Solution

The update flow now captures the pre-update run state and restores it after recreating containers:

- **Standalone**: if the old container was not running, the new one is created with `docker create` (same config, not started) instead of `docker run -d`.
- **Compose**: services are split by pre-update state via the project's container labels:
  - running services → `compose up -d --force-recreate <services>`
  - stopped services (or services without a container) → `compose create --force-recreate <services>` (new image swapped in, container left stopped)
  - covers single-service updates, *restart full project*, and bulk *update all* (all go through `UpdateProjectAsync`).

New `ContainerRunStateHelper` (in `Utils/`) holds the pure decision logic: state classification and per-service run-state mapping from container labels.

## Notes / edge cases

- Paused and restarting containers are treated as running: a recreate cannot restore those exact states, so starting the new container is the closest match.
- If container states cannot be read (Docker API error), the recreate falls back to starting everything (previous behavior) rather than failing the update.
- Operation logs and SSE progress messages now mention when a container/service is left stopped.
- i18n: the *restart after update* checkbox hint (en/fr) now states that stopped containers stay stopped.

## Tests

- New `ContainerRunStateHelperTests` (state classification, project/label filtering, multi-replica services, case-insensitive project match).
- `dotnet test`: 480 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)